### PR TITLE
US000000 - Cardstack Revisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/search-client/parser/operator.types.ts
+++ b/src/search-client/parser/operator.types.ts
@@ -81,7 +81,11 @@ export class SQXOperatorAnd extends SQXGroupBase<SQXOperatorBase>
     }
 
     public toJson(): any {
-        return {"and": this.items.map( condition => condition.toJson() ) };
+        if ( this.items.length === 1 ) {
+            return this.items[0].toJson();
+        } else {
+            return {"and": this.items.map( condition => condition.toJson() ) };
+        }
     }
 }
 

--- a/test/search-client/sqx.spec.ts
+++ b/test/search-client/sqx.spec.ts
@@ -110,6 +110,37 @@ describe('SQX Parser', () => {
             expect( errorCount ).to.equal( 0 );
         } );
 
+        it("should collapse AND clauses with single operators in them", () => {
+            let json = {
+                  "where":{
+                     "and":[
+                        {
+                           "=":[
+                              {
+                                 "source": "a"
+                              },
+                              true
+                           ]
+                        }
+                     ]
+                  }
+               };
+            let query = SQXSearchQuery.fromJson( json );
+            let converted = query.toConditionString();
+            let expressedJson = query.toJson();
+            expect( converted ).to.equal( "a = true" );
+            expect( expressedJson ).to.eql( {
+                'where': {
+                   "=":[
+                      {
+                         "source": "a"
+                      },
+                      true
+                   ]
+                }
+            } );
+        } );
+
         it( "should identify errors in badly formed queries", () => {
             let errorCount = 0;
             let brokenQueries = [


### PR DESCRIPTION
- Allow automatic property/value filter extraction
- Allow automatic aggregations based on loaded data, and calculations of
  pre- and post- filter summations

Should allow much of the "customized" behavior of the notification
cardstack views to be collapsed back into the underlying cardstack
model, while at the same time extending the cardstack to handle more
common use cases out-of-the-box.

- Also includes one or two changes to route types