### PR TITLE
ENG-4037 - Correlation rule doesn't honor search string for CIDR_MATCH

### DIFF
--- a/src/search-client/parser/operator.types.ts
+++ b/src/search-client/parser/operator.types.ts
@@ -883,7 +883,7 @@ export class SQXComparatorCIDRMatch extends SQXOperatorBase
 
     public fromParser( cursor:SQXParseCursor, tokenIndex:number ) {
         if ( tokenIndex < 1 || tokenIndex + 1 >= cursor.tokens.length ) {
-            throw new SQXParseError( "CIDR match operator must be used in the form `property` CIDR `value`", cursor.expression, cursor.token() );
+            throw new SQXParseError( "CIDR_MATCH operator must be used in the form `property` CIDR_MATCH `value`", cursor.expression, cursor.token() );
         }
 
         this.property = SQXPropertyRef.fromToken( cursor.token( tokenIndex - 1 ) );
@@ -895,7 +895,7 @@ export class SQXComparatorCIDRMatch extends SQXOperatorBase
     }
 
     public toQueryString():string {
-        return `${this.property.toQueryString()} CIDR ${this.value.toQueryString()}`;
+        return `${this.property.toQueryString()} CIDR_MATCH ${this.value.toQueryString()}`;
     }
 
     public toJson():any {


### PR DESCRIPTION
[ENG-4037](https://alertlogic.atlassian.net/browse/ENG-4037): Correlation rule doesn't honor search string for CIDR_MATCH

Before:
<img width="600" alt="Before" src="https://user-images.githubusercontent.com/1220121/82692927-f1f8c180-9c36-11ea-9ccd-911cde8b4213.png">


After:
<img width="600" alt="After" src="https://user-images.githubusercontent.com/1220121/82692963-fcb35680-9c36-11ea-9131-ce4b17a4c887.png">
