### PR TITLE
Refactor to support BaseAPIClient traffic (v1.0.27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -40,85 +40,15 @@ import {
     AlStopwatch,
     AlTriggerStream,
 } from "../common/utility";
+import {
+    APIExecutionLogItem,
+    APIExecutionLogSummary,
+    APIRequestParams
+} from './types';
 import { AlClientBeforeRequestEvent } from './events';
 import { AIMSSessionDescriptor } from '../aims-client/types';
 
 export type AlEndpointsServiceCollection = {[serviceName:string]:string};
-
-/**
- * Describes a single request to be issued against an API.
- * Please notice that it extends the underlying AxiosRequestConfig interface,
- * whose properties are detailed in node_modules/axios/index.d.ts or at https://www.npmjs.com/package/axios#request-config.
- */
-export interface APIRequestParams extends AxiosRequestConfig {
-  /**
-   * The following parameters are used to resolve the correct service location and request path.
-   * The presence of `service_name` on a request triggers this process.
-   */
-  service_stack?:string;            //  Indicates which service stack the request should be issued to.  This should be one of the location identifiers in @al/common's AlLocation.
-  service_name?: string;            //  Which service are we trying to talk to?
-  residency?: string;               //  What residency domain do we prefer?  Defaults to 'default'.
-  version?: string|number;          //  What version of the service do we want to talk to?
-  account_id?: string;              //  Which account_id's data are we trying to access/modify through the service?
-  context_account_id?:string;       //  If provided, uses the given account's endpoints/residency to determine service URLs _without_ adding the account ID to the request path.
-  path?: string;                    //  What is the path of the specific command within the resolved service that we are trying to interact with?
-  noEndpointsResolution?:boolean;   //  If set and truthy, endpoints resolution will *not* be used before the request is issued.
-  rawResponse?:boolean;             //  If set and truthy, the entire response object (not just its data payload) will be emitted as the result of a successful request.
-
-  /**
-   * Should data fetched from this endpoint be cached?  0 ignores caching, non-zero values are treated as milliseconds to persist retrieved data in local memory.
-   * If provided, `cacheKey` is used to identity unique and redundant/overlapping GET requests in place of a fully qualified URL.
-   */
-  ttl?: number|boolean;
-  cacheKey?:string;
-  disableCache?:boolean;
-  /**
-   *  Specifies an array of alternate cache keys to clear, in a call.
-   *  Example: ["/entity/info/12345","https://api.allapis.com/service/v1/2534/data"]
-   *           This will delete both GET requests from browser cache and
-   *           local storage cache.
-   */
-  flushCacheKeys?:string[];
-
-  /**
-   * If automatic retry functionality is desired, specify the maximum number of retries and interval multiplier here.
-   */
-  retry_count?: number;             //  Maximum number of retries
-  retry_interval?: number;          //  Delay between any two retries = attemptIndex * retryInterval, defaults to 1000ms
-
-  curl?:boolean;                    //    Emit curl diagnostic output for this request
-
-  /**
-   * @deprecated If provided, populates Headers.Accept
-   */
-  accept_header?: string;
-
-  /**
-   * @deprecated If provided, is simply copied to axios' `responseType` property
-   */
-  response_type?: string;
-}
-
-/**
- * Describes an execution request with all details or verbose an tracking purposes.
- */
-export interface APIExecutionLogItem {
-  method?: Method;                 // Request Method.
-  url?: string;                    // Request URL.
-  responseCode?: number;           // Response Code.
-  responseContentLength?: number;  // Response content length.
-  durationMs?: number;             // Total time to send and receive request.
-  errorMessage?: string;           // If something bad happens.
-}
-
-/**
- * Describes an execution request with all details or verbose an tracking purposes.
- */
-export interface APIExecutionLogSummary {
-  numberOfRequests?: number;  // Number of requests.
-  totalRequestTime?: number;  // Total request time.
-  totalBytes?: number;        // Total bytes.
-}
 
 export class AlApiClient
 {
@@ -136,6 +66,7 @@ export class AlApiClient
   public events:AlTriggerStream = new AlTriggerStream();
   public verbose:boolean = false;
   public collectRequestLog:boolean = false;
+  public mockMode:boolean = false;              //  If true, requests will be normalized but not actually dispatched.
   public defaultAccountId:string = null;        //  If specified, uses *this* account ID to resolve endpoints if no other account ID is explicitly specified
 
   private storage = AlCabinet.local( 'apiclient.cache' );
@@ -835,6 +766,10 @@ export class AlApiClient
       console.log( config );
       console.log( this.requestToCurlCommand( config ) );
     }
+    if ( this.mockMode ) {
+        return new Promise( ( resolve, reject ) => {
+        } );
+    }
     return ax( config ).then( response => {
                                 if ( attemptIndex > 0 ) {
                                   console.warn(`Notice: resolved request for ${config.url} with retry logic.` );
@@ -958,4 +893,4 @@ export class AlApiClient
 }
 
 /* tslint:disable:variable-name */
-export const AlDefaultClient = AlGlobalizer.instantiate( 'ALClient', () => new AlApiClient() );
+export const AlDefaultClient = AlGlobalizer.instantiate( 'AlDefaultClient', () => new AlApiClient() );

--- a/src/client/events/index.ts
+++ b/src/client/events/index.ts
@@ -3,11 +3,12 @@ import {
     AlTrigger,
     AlTriggeredEvent,
 } from "../../common";
+import { APIRequestParams } from '../types';
 
 @AlTrigger( 'AlClientBeforeRequest' )
 export class AlClientBeforeRequestEvent extends AlTriggeredEvent<void>
 {
-    constructor( public request:AxiosRequestConfig ) {
+    constructor( public request:APIRequestParams ) {
         super();
     }
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,8 +1,8 @@
+export { AlMockAxiosResponse, APIRequestParams } from './types';
 export * from './events';
 export {
     AlEndpointsServiceCollection,
     AlApiClient,
     AlDefaultClient,
-    AlDefaultClient as ALClient,    /* @deprecated */
-    APIRequestParams
+    AlDefaultClient as ALClient    /* @deprecated */
 } from './al-api-client';

--- a/src/client/types/index.ts
+++ b/src/client/types/index.ts
@@ -1,0 +1,89 @@
+import {
+    AxiosRequestConfig,
+    AxiosResponse,
+    Method
+} from 'axios';
+
+/**
+ * Describes an execution request with all details or verbose an tracking purposes.
+ */
+export interface APIExecutionLogItem {
+    method?: Method;                 // Request Method.
+    url?: string;                    // Request URL.
+    responseCode?: number;           // Response Code.
+    responseContentLength?: number;  // Response content length.
+    durationMs?: number;             // Total time to send and receive request.
+    errorMessage?: string;           // If something bad happens.
+}
+
+/**
+ * Describes an execution request with all details or verbose an tracking purposes.
+ */
+export interface APIExecutionLogSummary {
+    numberOfRequests?: number;  // Number of requests.
+    totalRequestTime?: number;  // Total request time.
+    totalBytes?: number;        // Total bytes.
+}
+
+/**
+ * Describes a single request to be issued against an API.
+ * Please notice that it extends the underlying AxiosRequestConfig interface,
+ * whose properties are detailed in node_modules/axios/index.d.ts or at https://www.npmjs.com/package/axios#request-config.
+ */
+export interface APIRequestParams extends AxiosRequestConfig {
+    /**
+    * The following parameters are used to resolve the correct service location and request path.
+    * The presence of `service_name` on a request triggers this process.
+    */
+    service_stack?:string;            //  Indicates which service stack the request should be issued to.  This should be one of the location identifiers in @al/common's AlLocation.
+    service_name?: string;            //  Which service are we trying to talk to?
+    residency?: string;               //  What residency domain do we prefer?  Defaults to 'default'.
+    version?: string|number;          //  What version of the service do we want to talk to?
+    account_id?: string;              //  Which account_id's data are we trying to access/modify through the service?
+    context_account_id?:string;       //  If provided, uses the given account's endpoints/residency to determine service URLs _without_ adding the account ID to the request path.
+    path?: string;                    //  What is the path of the specific command within the resolved service that we are trying to interact with?
+    noEndpointsResolution?:boolean;   //  If set and truthy, endpoints resolution will *not* be used before the request is issued.
+    rawResponse?:boolean;             //  If set and truthy, the entire response object (not just its data payload) will be emitted as the result of a successful request.
+
+    /**
+    * Should data fetched from this endpoint be cached?  0 ignores caching, non-zero values are treated as milliseconds to persist retrieved data in local memory.
+    * If provided, `cacheKey` is used to identity unique and redundant/overlapping GET requests in place of a fully qualified URL.
+    */
+    ttl?: number|boolean;
+    cacheKey?:string;
+    disableCache?:boolean;
+    /**
+    *  Specifies an array of alternate cache keys to clear, in a call.
+    *  Example: ["/entity/info/12345","https://api.allapis.com/service/v1/2534/data"]
+    *           This will delete both GET requests from browser cache and
+    *           local storage cache.
+    */
+    flushCacheKeys?:string[];
+
+    /**
+    * If automatic retry functionality is desired, specify the maximum number of retries and interval multiplier here.
+    */
+    retry_count?: number;             //  Maximum number of retries
+    retry_interval?: number;          //  Delay between any two retries = attemptIndex * retryInterval, defaults to 1000ms
+
+    curl?:boolean;                    //    Emit curl diagnostic output for this request
+
+    /**
+    * @deprecated If provided, populates Headers.Accept
+    */
+    accept_header?: string;
+
+    /**
+    * @deprecated If provided, is simply copied to axios' `responseType` property
+    */
+    response_type?: string;
+}
+
+export class AlMockAxiosResponse implements AxiosResponse<any> {
+    public statusText:string = '';
+    public headers:any = {};
+    public config:AxiosRequestConfig;
+
+    constructor( public status:number, public data:any ) {
+    }
+}

--- a/src/search-client/search-client.v2.ts
+++ b/src/search-client/search-client.v2.ts
@@ -2,7 +2,7 @@
  * A client for interacting with the Alert Logic Search Public API.
  */
 import {
-    ALClient,
+    AlDefaultClient,
     APIRequestParams,
 } from "../client";
 
@@ -148,7 +148,7 @@ class AlSearchClientV2 {
         if (additionalParams) {
             submitRequestArgs.params = additionalParams;
         }
-        const results = await ALClient.post(submitRequestArgs);
+        const results = await AlDefaultClient.post(submitRequestArgs);
 
         return results as AlSearchSubmitV2;
     }
@@ -166,7 +166,7 @@ class AlSearchClientV2 {
         if (additionalParams) {
             fetchRequestArgs.params = additionalParams;
         }
-        const results = await ALClient.get(fetchRequestArgs);
+        const results = await AlDefaultClient.get(fetchRequestArgs);
 
         return results as AlSearchGetV2;
     }
@@ -181,7 +181,7 @@ class AlSearchClientV2 {
      * @return Observable<SearchStatusV2>
      */
     async status(accountId: string, uuid: string): Promise<AlSearchStatusV2> {
-        const status = await ALClient.get({
+        const status = await AlDefaultClient.get({
             service_name: this.serviceName,
             version: 2,
             account_id: accountId,
@@ -195,7 +195,7 @@ class AlSearchClientV2 {
      *  Delete a currently executing search operation in the backend
      */
     async delete(accountId: string, uuid: string): Promise<any> {
-        const response = await ALClient.delete({
+        const response = await AlDefaultClient.delete({
             service_name: this.serviceName,
             version: 2,
             account_id: accountId,
@@ -208,7 +208,7 @@ class AlSearchClientV2 {
      *  Get expert mode search grammar
      */
     async getGrammar(): Promise<AlSearchSQLGrammar> {
-        const grammar = await ALClient.get({
+        const grammar = await AlDefaultClient.get({
             service_name: this.serviceName,
             version: 2,
             path: `/grammar`,

--- a/src/search-client/search-stylist-client.ts
+++ b/src/search-client/search-stylist-client.ts
@@ -2,7 +2,7 @@
  * A client for interacting with the Alert Logic Search Stylist API.
  */
 import {
-    ALClient,
+    AlDefaultClient,
     APIRequestParams,
 } from "../client";
 
@@ -36,9 +36,9 @@ class AlSearchStylist {
             fetchRequestArgs.headers.Accept = 'text/csv';
             fetchRequestArgs.responseType = 'blob';
 
-            return ALClient.get(fetchRequestArgs);
+            return AlDefaultClient.get(fetchRequestArgs);
         }
-        return ALClient.get<AlSearchGetV2>(fetchRequestArgs);
+        return AlDefaultClient.get<AlSearchGetV2>(fetchRequestArgs);
     }
 }
 

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -97,10 +97,12 @@ export class AlSessionInstance
     constructor( client:AlApiClient = null ) {
       this.client = client || AlDefaultClient;
       this.notifyStream.siphon( this.client.events );
-      this.notifyStream.attach( AlClientBeforeRequestEvent, ( event:any ) => {
+      this.notifyStream.attach( AlClientBeforeRequestEvent, ( event:AlClientBeforeRequestEvent ) => {
           if ( this.sessionIsActive ) {
-              event.request.headers = event.request.headers || {};
-              event.request.headers['X-AIMS-Auth-Token'] = this.getToken();
+              if ( event.request.service_stack === AlLocation.InsightAPI || event.request.service_stack === AlLocation.GlobalAPI ) {
+                  event.request.headers = event.request.headers || {};
+                  event.request.headers['X-AIMS-Auth-Token'] = this.getToken();
+              }
           }
       } );
       /**

--- a/test/session/al-session.spec.ts
+++ b/test/session/al-session.spec.ts
@@ -312,7 +312,7 @@ describe('AlSession', () => {
       expect( session.isActive() ).to.equal( true );
 
       //    Secondary test: make sure the AlClientBeforeRequest hook works
-      let event = new AlClientBeforeRequestEvent( { url: 'https://api.cloudinsight.alertlogic.com', headers: {} } );
+      let event = new AlClientBeforeRequestEvent( { service_stack: 'insight:api', url: 'https://api.cloudinsight.alertlogic.com', headers: {} } );
       session.notifyStream.trigger( event );
       expect( event.request.headers.hasOwnProperty( 'X-AIMS-Auth-Token' ) ).to.equal( true );
       expect( event.request.headers['X-AIMS-Auth-Token'] ).to.equal( exampleSession.authentication.token );


### PR DESCRIPTION
- Updated trigger types to handle event typing of callback more
  reasonably
- Added logic to only add X-AIMS-Auth-Token for appropriate API calls
- Refactored client types to make APIRequestParams available separately
- Fixed session test