### PR TITLE
ENG-7117 - Experience Flag Type Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/locator/al-navigation.types.ts
+++ b/src/common/locator/al-navigation.types.ts
@@ -21,15 +21,42 @@ export interface AlNavigationSchema
     conditions: {[conditionId:string]:AlRouteCondition};
 }
 
+export interface AlExperienceToggle
+{
+    after?:string|number;
+    before?:string|number;
+    accounts?:string[];
+    environments?:string[];
+}
+
 /**
  * Describes the entry location, availability criteria, and prompt behaviors of a specific experience (for the purposes of this
  * type, and "experience" = a specific variation or common subset of a feature.
  */
 export interface AlExperienceMapping
 {
-    name:string;                    //  Decorative
-    entryRoute:AlRouteAction;       //  A trigger or link that invokes the experience
-    availabilityQuery:string|any;   //  A searchlib compatible expression determining whether the experience is available to a given context, in either raw or SQL-style form
+    /*
+     * A descriptive name for the experience
+     */
+    name:string;
+
+    /**
+     * A route or trigger that can be used to imperatively invoke the experience
+     */
+    entryRoute:AlRouteAction;
+
+    /**
+     * A searchlib compatible expression determining whether the experience is available to a given context,
+     * in either raw or SQL-style form.
+     */
+    availabilityQuery:string|any;
+
+    /**
+     * An optional boolean, toggle, or array of toggles that determine when this experience should be enabled.  If provided,
+     * a positive match will supercede `availabilityQuery`.  This can be used to schedule enablement for specific customers
+     * in specific environments in advance of the addition of an entitlement.
+     */
+    trigger:AlExperienceToggle|AlExperienceToggle[]|boolean;
 
     /**
      * If provided, defines the zero state to provide when an experience isn't available.


### PR DESCRIPTION
Expands `AlExperienceMapping` to include an optional set of "triggers"
that can be used to determine whether an experience should be available
under certain fixed conditions -- by environment, account, and time.