### PR TITLE
VTT-28: integrate with new accessible endpoints enpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.51",
+  "version": "1.1.0-beta.1",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -50,16 +50,16 @@ stages:
                 PKGNAME=$(node -e 'console.log(require("./package.json").name)')
                 echo "⚠️ **WARNING** - Merging this pull request will result in a publish of **$PKGNAME** to npm from version **$LATEST_VERSION** to **$PKGVERSION**" >> comments.txt
               fi
-              
+
               #comments api call
               bin/hub api repos/alertlogic/$ALPS_REPO_NAME/issues/$ALPS_PR_NUMBER/comments --field body=@comments.txt
-            
+
             - echo done
 
     -
         name: Master Push - Publish
         when:
-            - push: ['master']
+            - push: ['master', 'Datacenter-Stuff']
         image: node:13
         compute_size: small
         commands:
@@ -69,7 +69,7 @@ stages:
             - export CHROME_BIN='/usr/bin/google-chrome'
             - |
               set -ex
-              
+
               printenv
 
               if [ -z "$NPM_TOKEN" ]
@@ -77,32 +77,32 @@ stages:
                   echo "\$NPM_TOKEN is empty"
                   exit 1
               fi
-              
+
               #git config --global --add url."git@github.com:".insteadOf "https://github.com/"
 
-              
+
               echo //registry.npmjs.org/:_authToken="$NPM_TOKEN" > .npmrc
               npm whoami
-              
+
               PKGNAME=$(node -e 'console.log(require("./package.json").name)')
               PKGVERSION=$(node -e 'console.log(require("./package.json").version)')
               V_VERSION=v$PKGVERSION
               WORDCOUNT=$(npm view "${PKGNAME}@${PKGVERSION}" | wc -c)
-              
+
               #git tag -a $V_VERSION -m "$PKGNAME release $V_VERSION" HEAD
 
               # Release section
               curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.2
               GITHUB_TOKEN=$ALPS_GH_TOKEN
-              
+
               npm install
-              
+
               if [ "$WORDCOUNT" -eq 0  ]; then
                  echo "PUBLISHING $PKGNAME $PKGVERSION"
                  npm run build
                 # git push origin $V_VERSION
-                 npm publish --access public
-                 
+                 npm publish --access public --tag=beta
+
                  echo "Continuous Delivery release for ${PKGNAME}@${PKGVERSION}" > release_notes.txt
 
                  echo "CREATING RELEASE FOR ${PKGNAME}@${PKGVERSION}"
@@ -110,7 +110,7 @@ stages:
                  # See: https://hub.github.com/hub-release.1.html
                  bin/hub release create -F release_notes.txt -t $CODEBUILD_SOURCE_VERSION $V_VERSION
                  # End release section
-              
+
               else
                  echo "NOT PUBLISHING $PKGNAME $PKGVERSION"
               fi

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -49,14 +49,20 @@ import {
 import { AlClientBeforeRequestEvent } from './events';
 import { AIMSSessionDescriptor } from '../aims-client/types';
 
-export type AlEndpointsServiceCollection = {[serviceName:string]:string};
+export type AlEndpointsServiceCollection = {
+    [serviceName:string]: {
+        [residency:string]:{
+            [endpointHost:string]:string
+        }
+    }
+};
 
 export class AlApiClient
 {
   /**
    * The following list of services are the ones whose endpoints will be resolved by default.  Added globally/commonly used services here for optimized API performance.
    */
-  protected static defaultServiceList = [ "aims", "subscriptions", "search", "sources", "assets_query", "assets_write", "dashboards", "iris", "suggestions", "cargo" ];
+  protected static defaultServiceList = [ "aims", "subscriptions", "search", "sources", "assets_query", "assets_write", "dashboards", "iris", "suggestions", "cargo", "herald" ];
   protected static defaultServiceParams = {
     service_stack:      AlLocation.InsightAPI,  //  May also be AlLocation.GlobalAPI, AlLocation.EndpointsAPI, or ALLocation.LegacyUI
     residency:          'default',              //  "us" or "emea" or "default"
@@ -529,7 +535,10 @@ export class AlApiClient
    */
   public async getServiceEndpoints( accountId:string, requestList?:string[] ):Promise<AlEndpointsServiceCollection> {
     const environment = AlLocatorService.getCurrentEnvironment();
+    const context = AlLocatorService.getContext();
+    console.log(context.residency);
     const cacheKey = `/endpoints/${environment}/${accountId}`;
+
     if ( ! requestList ) {
       requestList = AlApiClient.defaultServiceList;
     }
@@ -542,7 +551,7 @@ export class AlApiClient
     }
     const endpointsRequest:APIRequestParams = {
       method: "POST",
-      url: AlLocatorService.resolveURL( AlLocation.GlobalAPI, `/endpoints/v1/${accountId}/residency/default/endpoints` ),
+      url: AlLocatorService.resolveURL( AlLocation.GlobalAPI, `/endpoints/v1/${accountId}/endpoints` ),
       data: requestList,
       aimsAuthHeader: true
     };
@@ -550,8 +559,16 @@ export class AlApiClient
               .then( response => {
                   existingEndpoints = this.getCachedValue<AlEndpointsServiceCollection>( cacheKey );        //    retrieve cache again, in case it has been modified by others
                   let translated:AlEndpointsServiceCollection = deepMerge( {}, existingEndpoints );
-                  Object.entries( response.data as AlEndpointsServiceCollection ).forEach( ( [ serviceName, endpointHost ] ) => {
-                    translated[serviceName] = ( endpointHost as string ).startsWith( "http") ? endpointHost : `https://${endpointHost}`;        // ensure that all domains are prefixed with protocol
+                  Object.entries( response.data as AlEndpointsServiceCollection ).forEach( ( [ serviceName, residencyLocations ] ) => {
+                      Object.entries(residencyLocations).forEach(([residencyName, endpointHost]) => {
+                          Object.entries(endpointHost).forEach(([endpointHostId, endpointHost]) => {
+                              translated[serviceName] = {
+                                [residencyName]: {
+                                    [endpointHostId]: (endpointHost as string).startsWith("http") ? endpointHost : `https://${endpointHost}` // ensure that all domains are prefixed with protocol
+                                }
+                              };
+                          });
+                      });
                   } );
                   this.setCachedValue( cacheKey, translated, 15 * 60 * 1000 );
                   return translated;
@@ -559,7 +576,15 @@ export class AlApiClient
                 console.warn(`Could not retrieve data for endpoints for [${requestList.join(",")}]; using defaults for environment '${AlLocatorService.getCurrentEnvironment()}'; disabling caching` );
                 existingEndpoints = this.getCachedValue<AlEndpointsServiceCollection>( cacheKey );
                 let serviceLocations:AlEndpointsServiceCollection = deepMerge( {}, existingEndpoints );
-                requestList.forEach( serviceId => { serviceLocations[serviceId] = AlLocatorService.resolveURL( AlLocation.InsightAPI ); } );
+                requestList.forEach( serviceId => {
+                    if(!serviceLocations.hasOwnProperty(serviceId)) {
+                        serviceLocations[serviceId] = {};
+                    }
+                    if(serviceLocations.hasOwnProperty(serviceId) && !serviceLocations[serviceId].hasOwnProperty(context.residency)) {
+                        serviceLocations[serviceId][context.residency] = {};
+                    }
+                    serviceLocations[serviceId][context.residency][context.insightLocationId]= AlLocatorService.resolveURL( AlLocation.InsightAPI );
+                } );
                 return Promise.resolve( serviceLocations );
               } );
   }
@@ -636,11 +661,19 @@ export class AlApiClient
 
   protected async calculateRequestURL( params: APIRequestParams ):Promise<string> {
     let fullPath:string = null;
+    const context = AlLocatorService.getContext();
     if ( params.service_name && params.service_stack === AlLocation.InsightAPI && ! params.noEndpointsResolution ) {
       // Utilize the endpoints service to determine which location to use for this service/account pair
       const serviceCollection = await this.prepare( params );
       if ( serviceCollection.hasOwnProperty( params.service_name ) ) {
-        fullPath = serviceCollection[params.service_name];
+        // Any global service entries returned are always stored in a global -> insight-global nested property
+        if(serviceCollection[params.service_name]['global']) {
+            fullPath = serviceCollection[params.service_name]['global']['insight-global'];
+        } else {
+            if(serviceCollection[params.service_name][context.residency] && serviceCollection[params.service_name][context.residency][context.insightLocationId]){
+                fullPath = serviceCollection[params.service_name][context.residency][context.insightLocationId];
+            }
+        }
       }
     }
     if ( ! fullPath ) {

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -536,7 +536,6 @@ export class AlApiClient
   public async getServiceEndpoints( accountId:string, requestList?:string[] ):Promise<AlEndpointsServiceCollection> {
     const environment = AlLocatorService.getCurrentEnvironment();
     const context = AlLocatorService.getContext();
-    console.log(context.residency);
     const cacheKey = `/endpoints/${environment}/${accountId}`;
 
     if ( ! requestList ) {
@@ -560,8 +559,8 @@ export class AlApiClient
                   existingEndpoints = this.getCachedValue<AlEndpointsServiceCollection>( cacheKey );        //    retrieve cache again, in case it has been modified by others
                   let translated:AlEndpointsServiceCollection = deepMerge( {}, existingEndpoints );
                   Object.entries( response.data as AlEndpointsServiceCollection ).forEach( ( [ serviceName, residencyLocations ] ) => {
-                      Object.entries(residencyLocations).forEach(([residencyName, endpointHost]) => {
-                          Object.entries(endpointHost).forEach(([endpointHostId, endpointHost]) => {
+                      Object.entries(residencyLocations).forEach(([residencyName, residencyHost]) => {
+                          Object.entries(residencyHost).forEach(([endpointHostId, endpointHost]) => {
                               translated[serviceName] = {
                                 [residencyName]: {
                                     [endpointHostId]: (endpointHost as string).startsWith("http") ? endpointHost : `https://${endpointHost}` // ensure that all domains are prefixed with protocol

--- a/test/client/al-api-client.spec.ts
+++ b/test/client/al-api-client.spec.ts
@@ -51,19 +51,43 @@ const defaultAuthResponse = {
 
 beforeEach(() => {
     xhrMock.setup();
-    AlLocatorService.setContext( { environment: "integration" } );      //  for unit tests, assume integration environment
+    AlLocatorService.setContext( { environment: "integration", insightLocationId: "insight-us-virginia" } );      //  for unit tests, assume integration environment
     ALClient['endpointResolution']["integration"] = {};
     ALClient['endpointResolution']["integration"]["0"] = Promise.resolve( {
-      "cargo": "https://api.global-integration.product.dev.alertlogic.com",
-      "kevin": "https://kevin.product.dev.alertlogic.com",
-      'search': "https://api.global-fake-integration.product.dev.alertlogic.com",
-      "aims": "https://api.global-integration.product.dev.alertlogic.com"
-    } );
+        "cargo": {
+            "US": {
+                "insight-us-virginia": "https://api.global-integration.product.dev.alertlogic.com"
+            }
+        },
+        "kevin": {
+            "US": {
+                "insight-us-virginia": "https://kevin.product.dev.alertlogic.com"
+            }
+        },
+        "search": {
+          "US": {
+            "insight-us-virginia": "https://api.global-fake-integration.product.dev.alertlogic.com"
+          }
+        },
+        "aims": {
+          "global": {
+            "insight-global": "https://api.global-integration.product.dev.alertlogic.com"
+        }
+      }
+    });
     ALClient['endpointResolution']["integration"]["2"] = ALClient['endpointResolution']["integration"][0];
     ALClient['endpointResolution']["integration"]["3"] = Promise.resolve( {
-      "cargo": "https://api.global-integration.product.dev.alertlogic.com",
-      "kevin": "https://kevin.product.dev.alertlogic.co.uk"
-    } );
+      "cargo": {
+        "US": {
+            "insight-us-virginia": "https://api.global-integration.product.dev.alertlogic.com"
+        }
+      },
+      "kevin": {
+          "US": {
+            "insight-us-virginia": "https://kevin.product.dev.alertlogic.co.uk"
+            }
+        }
+    });
     ALClient['endpointResolution']["integration"]["67108880"] = ALClient['endpointResolution']["integration"][0];
 } );
 afterEach(() => {
@@ -121,7 +145,7 @@ describe('when calculating request URLs', () => {
   });
   describe("and an exception is thrown from the `endpoints` service", () => {
     it("should fall back to default values", async () => {
-      xhrMock.post( 'https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/10101010/residency/default/endpoints', once({
+      xhrMock.post( 'https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/10101010/endpoints', once({
         status: 500,
         body: 'Internal Error Or Something'
       }) );


### PR DESCRIPTION
### VTT-28
https://alertlogic.atlassian.net/browse/VTT-28

An initial implementation to integrate with a new endpoint on the endpoints service which will return all endpoints that an account has access to - https://console.account.alertlogic.com/users/api/endpoints/index.html#api-1_Query_Endpoints-GetServicesEndpoints

This will allow for parent accounts to view data for child accounts in the context of their children's own data residencies\locations.