### PR TITLE
ENG-0000 - Version 1.0.54

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/types/index.ts
+++ b/src/client/types/index.ts
@@ -29,18 +29,45 @@ export interface APIExecutionLogSummary {
  * Describes a single request to be issued against an API.
  * Please notice that it extends the underlying AxiosRequestConfig interface,
  * whose properties are detailed in node_modules/axios/index.d.ts or at https://www.npmjs.com/package/axios#request-config.
+ *
+ * IMPORTANT NOTE ON ENDPOINT RESOLUTION (7.24.2020)
+ *
+ * The request properties `target_endpoint`, `service_stack`, `service_name`, `residency`, and `account_id`,
+ * `context_account_id`, `noEndpointsResolution` are used in combination to determine how the base target URL
+ * should be calculated, using the following basic rules:  If a `url` is specified explicitly or the user is not authenticated,
+ * ALL of this logic will be ignored and the default endpoint values provided by AlLocatorService will be used instead.  Otherwise:
+ *
+ * - If `noEndpointsResolution` is set to true, endpoints resolution will be circumvented completely and AlLocatorService defaults
+ *   will be used instead.
+ *
+ * - If `target_endpoint` is provided, that string will be used as the key of the service to resolve.  Otherwise, if `service_stack`
+ *   references the Insight API stack and `service_name` is provided, then `service_name` will be used.  If neither of these
+ *   conditions is met, resolution will be circumvented just as if `noEndpointsResolution` were `true`.
+ *
+ * - Endpoints will be resolved for `context_account_id` (if set), otherwise `account_id`, and in the absence of an explicitly
+ *   indicated account, the active session's primary account ID (stored locally as `defaultAccountId`) will be used.
+ *
+ * - If residency is provided, it will override the residency associated with the active session's `activeDatacenter()`.
+ *
+ * The default behavior is influence by the default request values, which are
+ *      `service_stack`: `true`
+ *      `residency`: `default`
+ *
  */
+
 export interface APIRequestParams extends AxiosRequestConfig {
     /**
     * The following parameters are used to resolve the correct service location and request path.
     * The presence of `service_name` on a request triggers this process.
     */
+    target_endpoint?:string;          //  Which endpoint should be resolved for this request?  See note about endpoint resolution above.
     service_stack?:string;            //  Indicates which service stack the request should be issued to.  This should be one of the location identifiers in @al/common's AlLocation.
     service_name?: string;            //  Which service are we trying to talk to?
     residency?: string;               //  What residency domain do we prefer?  Defaults to 'default'.
     version?: string|number;          //  What version of the service do we want to talk to?
     account_id?: string;              //  Which account_id's data are we trying to access/modify through the service?
     context_account_id?:string;       //  If provided, uses the given account's endpoints/residency to determine service URLs _without_ adding the account ID to the request path.
+
     path?: string;                    //  What is the path of the specific command within the resolved service that we are trying to interact with?
     noEndpointsResolution?:boolean;   //  If set and truthy, endpoints resolution will *not* be used before the request is issued.
     aimsAuthHeader?:boolean;          //  If `true` AND the user is authenticated, forces the addition of the X-AIMS-Auth-Token header; if `false`, suppresses the header when it would ordinarily be added.

--- a/src/common/locator/al-locator.types.ts
+++ b/src/common/locator/al-locator.types.ts
@@ -326,7 +326,6 @@ export class AlLocatorMatrix
                     result = hit.location;
                     const baseUrl = this.getBaseUrl( targetURI );
                     if ( baseUrl !== result.uri ) {
-                        console.log(`Notice: application '${hit.location.locTypeId}' instance '${baseUrl}' differs from default '${result.uri}'; updating lookup table.` );
                         result.originalUri = result.uri;
                         result.uri = baseUrl;
                     }
@@ -624,7 +623,6 @@ export class AlLocatorMatrix
             if ( selected === null ) {
                 selected = insightLocation.alternatives[0];
             }
-            console.log(`Notice: treating insight location '%s' as '%s'`, this.context.insightLocationId, selected );       //  logging because this has historically been a point of great confusion
             this.context.insightLocationId = selected;
         }
         if ( insightLocation.residency && this.context.residency !== insightLocation.residency ) {

--- a/src/common/utility/error-utilities.ts
+++ b/src/common/utility/error-utilities.ts
@@ -1,0 +1,15 @@
+import { AlDefaultClient } from '../../client/al-api-client';
+import { AxiosResponse } from 'axios';
+import { AlBaseError } from '../errors';
+
+export function normalizeError( error:AxiosResponse|AlBaseError|string|any ):AlBaseError {
+    if ( AlDefaultClient.isResponse( error ) ) {
+        return new AlBaseError( error.statusText );
+    } else if ( error instanceof AlBaseError ) {
+        return error;
+    } else if ( typeof( error ) === 'string' ) {
+        return new AlBaseError( error );
+    } else {
+        return new AlBaseError( "An internal error has occurred." );
+    }
+}

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -108,7 +108,8 @@ export class AlSessionInstance
       AlLocation.GlobalAPI,
       AlLocation.IntegrationsAPI,
       AlLocation.GestaltAPI,
-      AlLocation.EndpointsAPI
+      AlLocation.EndpointsAPI,
+      AlLocation.AETunerAPI
     ];
 
 

--- a/test/client/al-api-client.spec.ts
+++ b/test/client/al-api-client.spec.ts
@@ -113,10 +113,16 @@ describe('when calculating request URLs', () => {
       //  expect the endpoints response for the context_account_id to be used instead of the dominant account_id's
       expect( endpointURL ).to.equal( `https://kevin.product.dev.alertlogic.co.uk/kevin/v1/67108880/some/endpoint` );
 
+      endpointURL = await ALClient['calculateRequestURL']( { service_name: 'cargo', target_endpoint: 'kevin', path: '/some/endpoint' } );
+      //  expect target endpoint ID to be honored
+      expect( endpointURL ).to.equal( `https://kevin.product.dev.alertlogic.com/cargo/some/endpoint` );
+
       ALClient.defaultAccountId = "67108880";
       endpointURL = await ALClient['calculateRequestURL']( { service_name: 'kevin', version: 16, path: 'some/arbitrary/endpoint', service_stack: AlLocation.InsightAPI } );
       expect( endpointURL ).to.equal( `https://kevin.product.dev.alertlogic.com/kevin/v16/some/arbitrary/endpoint` );
       ALClient.defaultAccountId = null;
+
+
     });
   });
   describe("and an exception is thrown from the `endpoints` service", () => {
@@ -443,7 +449,6 @@ describe('when flushCacheKeys is present',() => {
 
 describe('when collectRequestLog is set to true',() => {
     beforeEach(() => {
-      ALClient.verbose = true;
       ALClient.collectRequestLog = true;
     });
     afterEach(()=>{

--- a/test/search-client/sqx.spec.ts
+++ b/test/search-client/sqx.spec.ts
@@ -90,7 +90,6 @@ describe('SQX Parser', () => {
                 let queryString;
                 try {
                     let query = SQXSearchQuery.fromConditionString( original );
-                    console.log( query );
                     queryString = query.toConditionString();
                     json = query.toJson( true );
                     let reinterpreted = SQXSearchQuery.fromJson( json );

--- a/test/session/al-session.spec.ts
+++ b/test/session/al-session.spec.ts
@@ -483,7 +483,6 @@ describe('AlSession', () => {
             session.endDetection();
             let resolved = false;
             session.ready().then( () => {
-              console.log("Got session ready!" );
               resolved = true;
             }, ( error ) => {
               expect( true ).to.equal( false );


### PR DESCRIPTION
- Added `target_endpoint` property to APIRequestParams, which allows
  caller to indicate an arbitrary endpoint key for base URL resolution
  regardless of service_stack or service_name
- Added documentation for how endpoint resolution logic works
- Added AETuner API to list of default-authenticated service stacks
- Removed a bunch of unnecessary logging