### PR TITLE
ENG-0000 - Fixed FormData payload issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -86,7 +86,7 @@ export class AlApiClient
 
   constructor() {
       // temp to debug ie11
-      this.globalServiceParams = deepMerge( {}, AlApiClient.defaultServiceParams );
+      this.globalServiceParams = this.merge( {}, AlApiClient.defaultServiceParams );
   }
 
   /**
@@ -97,7 +97,7 @@ export class AlApiClient
     this.instance = null;
     this.executionRequestLog = [];
     this.storage.destroy();
-    this.globalServiceParams = deepMerge( {}, AlApiClient.defaultServiceParams );
+    this.globalServiceParams = this.merge( {}, AlApiClient.defaultServiceParams );
     return this;
   }
 
@@ -136,7 +136,7 @@ export class AlApiClient
    * Most notably, setting `noEndpointsResolution` to true will suppress endpoints resolution for all requests, and cause default endpoint values to be used.
    */
   public setGlobalParameters( parameters:APIRequestParams ):AlApiClient {
-    this.globalServiceParams = deepMerge( this.globalServiceParams, parameters );
+    this.globalServiceParams = this.merge( this.globalServiceParams, parameters );
     return this;
   }
 
@@ -502,7 +502,7 @@ export class AlApiClient
     if ( ! config.url ) {
       if ( 'target_endpoint' in config || 'service_name' in config || 'service_stack' in config ) {
         // If we are using endpoints resolution to determine our calculated URL, merge globalServiceParams into our configuration
-        config = deepMerge( {}, this.globalServiceParams, config );
+        config = this.merge( {}, this.globalServiceParams, config );
         config.url = await this.calculateRequestURL( config );
       } else {
         console.warn("Warning: malform request descriptor lacks a URL or properties to generate one", config );
@@ -897,6 +897,22 @@ export class AlApiClient
       if ( this.verbose ) {
           console.log.apply( console, (arguments as any) );
       }
+  }
+
+  /**
+   * Performs a shallow merge from any number of source objects to a single target object, and returns that target object.
+   * Essentially a cheap-and-easy replacement for Object.assign.
+   */
+  private merge( target:any, ...sources:any[] ):any {
+    sources.forEach( source => {
+      if ( typeof( source ) !== 'object' || source === null ) {
+        return;
+      }
+      Object.entries( source ).forEach( ( [ key, value ] ) => {
+        target[key] = value;
+      } );
+    } );
+    return target;
   }
 }
 

--- a/test/client/al-api-client.spec.ts
+++ b/test/client/al-api-client.spec.ts
@@ -71,6 +71,36 @@ afterEach(() => {
   ALClient.reset();
 });
 
+describe('merge function', () => {
+    it('should merge objects reliably', () => {
+        let source1 = {
+            a: true,
+            b: 3,
+            c: "kevin"
+        };
+        let source2 = {
+            a: false,
+            b: 4,
+            c: "kermit"
+        };
+        let source3 = {
+            b: -1,
+            c: "miss piggy"
+        };
+
+        let target = ALClient['merge']( {}, source1 );
+        expect( target ).to.deep.equal( source1 );
+
+        target = ALClient['merge']( {}, source1, source2 );
+        expect( target ).to.deep.equal( source2 );
+
+        target = ALClient['merge']( {}, source1, source3, source2 );
+        expect( target.a ).to.equal( false );
+        expect( target.b ).to.equal( 4 );
+        expect( target.c ).to.equal( "kermit" );
+    } );
+} );
+
 describe('when calculating request URLs', () => {
   describe('with no params supplied', () => {
     it('should throw an error', async () => {


### PR DESCRIPTION
Use of `deepMerge` to apply specific request configurations with default
values was trashing FormData instances.  Replaced with a shallow merge
algorithm in AlApiClient.