### PR TITLE
ENG-14639: making label optional in forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/forms/types.ts
+++ b/src/common/forms/types.ts
@@ -8,7 +8,7 @@ export interface AlDynamicFormControlElement {
     updateNotAllowed?: boolean;
     type: string;
     property: string;
-    label: string;
+    label?: string;
     secret?: string;
     description?: string;
     descriptionOnUpdate?: string;


### PR DESCRIPTION
in https://alertlogic.atlassian.net/browse/ENG-14639 the field payload does not require label