### PR TITLE
ENG-0000: cardstack local filtering logic update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/cardstack/al-cardstack-view.ts
+++ b/src/common/cardstack/al-cardstack-view.ts
@@ -543,6 +543,9 @@ export abstract class AlCardstackView< EntityType=any,
      * This is the default filter evaluator.
      */
     protected defaultFilterCb( entity:EntityType, properties:PropertyType, filter:AlCardstackActiveFilter<EntityType,PropertyType>, data?:any ) {
+        if(filter.property.remote) {
+            return true; // Filtering will have been performed by server, no further action required here
+        }
         let value = filter.property.property in properties ? properties[filter.property.property] : null;
         return filter.values.find( vDescr => vDescr.value === value ) ? true : false;
     }


### PR DESCRIPTION
Bypass local filtering of entities when the given filter is set to `remote: true` since filtering will already have been performed by the backend