### PR TITLE
ENG-16870: fix for initial local pagination calculation in al-cardstack-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.75",
+  "version": "1.0.76",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/cardstack/al-cardstack-view.ts
+++ b/src/common/cardstack/al-cardstack-view.ts
@@ -94,14 +94,15 @@ export abstract class AlCardstackView< EntityType=any,
 
             let ingestedCards = this.ingest( entities );
             this.rawCards = ingestedCards;
-
+            let sortByApplied = false;
             if( this.sortingBy && this.sortOrder && !this.sortingBy.remote) {
                 this.applySortBy(this.sortingBy,  this.sortOrder );
+                sortByApplied = true;
             }
 
             this.filteredCards = this.rawCards;
 
-            if ( this.characteristics.localPagination ) {
+            if ( this.characteristics.localPagination && !sortByApplied) {
                 let initialCards = this.filteredCards.slice(this.cards.length,  this.cards.length + this.itemsPerPage);
                 this.addNextSection( initialCards );
             } else {


### PR DESCRIPTION
### ENG-16870

Recently detected an issue in our cardstack views with local pagination enabled that the initial display of rendered cards is not actually being limited to the `itemsPerPage` amount.

This issue is specific to a `sortingBy` value being present AND `localPagination` set to true.

**Current Behaviour:**

Consider a cardstack configured with localPagination=true, a sortingBy property set, and the itemsPerPage property left at its default value of 50. Also consider that and 100 rows of data is returned

In the start() routine in al-cardstack-view:

- `applySortBy` is invoked where a `sortingBy` condition is present
- in this method, the final line invokes `applyFiltersAndSearch`
- this in turn calls `startPagination`
- and this results in `this.cards` getting set to 50 items correctly
- back to the start() routine this condition then gets met:

````
if ( this.characteristics.localPagination) {
                let initialCards = this.filteredCards.slice(this.cards.length,  this.cards.length + this.itemsPerPage);
                this.addNextSection( initialCards );
            } 
````

- this call to `addNextSection` adds a further 50 cards to the cardstack view, so 100 in total are now initially rendered

**Solution**

- Just adding a flag to detect when sorting has been applied already to avoid a further section of items getting added to the `cards` array