### PR TITLE
ENG-19821 - Built-in JSON Validation

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,5 +46,9 @@ module.exports = function(config){
                 },
         },
         singleRun: true,
+        captureTimeout: 210000,
+        browserDisconnectTolerance: 3,
+        browserDisconnectTimeout : 210000,
+        browserNoActivityTimeout : 210000,
     });
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "auth0-js": "^9.12.2",
     "axios": "^0.19.2",
-    "base64-js": "~1.3.0"
+    "base64-js": "~1.3.0",
+    "tv4": "^1.3.0"
   },
   "devDependencies": {
     "@types/auth0-js": "^9.12.4",

--- a/src/aims-client/aims.schematics.ts
+++ b/src/aims-client/aims.schematics.ts
@@ -1,0 +1,48 @@
+export const aimsTypeSchematics = {
+    "https://alertlogic.com/schematics/aims": {
+      definitions: {
+        user: {
+          type: "object",
+          properties: {
+            account_id: { type: "string" },
+            id: { type: "string" },
+            name: { type: "string" },
+            email: { type: "string" },
+            active: { type: "boolean" },
+            locked: { type: "boolean" },
+            version: { type: "number" },
+            created: { "$ref": "https://alertlogic.com/schematics/shared#definitions/changestamp" },
+            modified: { "$ref": "https://alertlogic.com/schematics/shared#definitions/changestamp" },
+          },
+          required: [ "account_id", "id", "name", "email", "created", "modified" ]
+        },
+        account: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            name: { type: "string" },
+            active: { type: "boolean" },
+            locked: { type: "boolean" },
+            version: { type: "number" },
+            accessible_locations: { type: "array", item: "string" },
+            default_location: { type: "string" },
+            mfa_required: { type: "boolean" },
+            created: { "$ref": "https://alertlogic.com/schematics/shared#definitions/changestamp" },
+            modified: { "$ref": "https://alertlogic.com/schematics/shared#definitions/changestamp" },
+          },
+          required: [ "id", "Name", "active", "accessible_locations", "default_location", "created", "modified" ]
+        },
+        authentication: {
+          type: "object",
+          properties: {
+            user: { "$ref": "#definitions/user" },
+            account: { "$ref": "#definitions/account" },
+            token: { type: "string" },
+            token_expiration: { type: "number" }
+          },
+          required: [ "user", "account", "token", "token_expiration" ]
+        }
+      }
+    }
+};
+

--- a/src/client/common.schematics.ts
+++ b/src/client/common.schematics.ts
@@ -1,0 +1,15 @@
+export const commonTypeSchematics = {
+    'https://alertlogic.com/schematics/shared': {
+      definitions: {
+        changestamp: {
+          type: "object",
+          properties: {
+            by: { type: "string" },
+            at: { type: "number" }
+          },
+          required: [ "by", "at" ],
+          additionalProperties: false
+        }
+      }
+    }
+};

--- a/src/client/types/index.ts
+++ b/src/client/types/index.ts
@@ -3,6 +3,7 @@ import {
     AxiosResponse,
     Method
 } from 'axios';
+import { AlValidationSchemaProvider } from '../../common/utility/al-validation.types';
 
 /**
  * Describes an execution request with all details or verbose an tracking purposes.
@@ -57,9 +58,9 @@ export interface APIExecutionLogSummary {
 
 export interface APIRequestParams extends AxiosRequestConfig {
     /**
-    * The following parameters are used to resolve the correct service location and request path.
-    * The presence of `service_name` on a request triggers this process.
-    */
+     *  The following parameters are used to resolve the correct service location and request path.
+     *  The presence of `service_name` on a request triggers this process.
+     */
     target_endpoint?:string;          //  Which endpoint should be resolved for this request?  See note about endpoint resolution above.
     service_stack?:string;            //  Indicates which service stack the request should be issued to.  This should be one of the location identifiers in @al/common's AlLocation.
     service_name?: string;            //  Which service are we trying to talk to?
@@ -74,23 +75,36 @@ export interface APIRequestParams extends AxiosRequestConfig {
     rawResponse?:boolean;             //  If set and truthy, the entire response object (not just its data payload) will be emitted as the result of a successful request.
 
     /**
-    * Should data fetched from this endpoint be cached?  0 ignores caching, non-zero values are treated as milliseconds to persist retrieved data in local memory.
-    * If provided, `cacheKey` is used to identity unique and redundant/overlapping GET requests in place of a fully qualified URL.
-    */
+     *  Should data retrieved from this endpoint be validated?  If provided, the response structure (which must be JSON) will be evaluated using the
+     *  indicated schema (which may contain a # fragment indicating a child template).
+     *  The caller may optionally indicate that only a subset of the document be validated (e.g., basePath: "elements.element" would evaluate only the
+     *  "element" structure inside an "elements" wrapper) or that the indicated element should be treated as an array of objects of the given type.
+     */
+    validation?: {
+        schema: string;
+        providers: AlValidationSchemaProvider|AlValidationSchemaProvider[];
+        basePath?: string;
+        asArray?: boolean;
+    };
+
+    /**
+     *  Should data fetched from this endpoint be cached?  0 ignores caching, non-zero values are treated as milliseconds to persist retrieved data in local memory.
+     *  If provided, `cacheKey` is used to identity unique and redundant/overlapping GET requests in place of a fully qualified URL.
+     */
     ttl?: number|boolean;
     cacheKey?:string;
     disableCache?:boolean;
     /**
-    *  Specifies an array of alternate cache keys to clear, in a call.
-    *  Example: ["/entity/info/12345","https://api.allapis.com/service/v1/2534/data"]
-    *           This will delete both GET requests from browser cache and
-    *           local storage cache.
-    */
+     *  Specifies an array of alternate cache keys to clear, in a call.
+     *  Example: ["/entity/info/12345","https://api.allapis.com/service/v1/2534/data"]
+     *           This will delete both GET requests from browser cache and
+     *           local storage cache.
+     */
     flushCacheKeys?:string[];
 
     /**
-    * If automatic retry functionality is desired, specify the maximum number of retries and interval multiplier here.
-    */
+     *  If automatic retry functionality is desired, specify the maximum number of retries and interval multiplier here.
+     */
     retry_count?: number;             //  Maximum number of retries
     retry_interval?: number;          //  Delay between any two retries = attemptIndex * retryInterval, defaults to 1000ms
 

--- a/src/common/errors/al-error.types.ts.backup
+++ b/src/common/errors/al-error.types.ts.backup
@@ -7,7 +7,7 @@
  * Copyright 2019 Alert Logic, Inc.
  */
 
-import { AxiosResponse, AxiosRequestConfig } from 'axios';
+import { AxiosResponse } from 'axios';
 
 /**
  * @public
@@ -28,6 +28,7 @@ export class AlBaseError extends Error
     constructor( message?:string, derivedFrom?:any ) {
         const trueProto = new.target.prototype;
         super(message);
+        this.origin = derivedFrom;
 
         this.__proto__ = trueProto;
     }
@@ -52,7 +53,7 @@ export class AlAPIServerError extends AlBaseError
 }
 
 /**
- * @deprecated
+ * @public
  *
  * The AlResponseValidationError is intended to alert of unexpected responses from an internal API.
  * These responses need to be identified separately from other errors so that the relevant
@@ -65,34 +66,9 @@ export class AlAPIServerError extends AlBaseError
  */
 export class AlResponseValidationError extends AlBaseError
 {
-    constructor( message:string, public errors:any[] = [] ) {
-        /* istanbul ignore next */
-        super( message );
-    }
-}
-
-/**
- * @public
- *
- * The AlDataValidationError is intended to alert of unexpected responses from an internal API.
- * These responses need to be identified separately from other errors so that the relevant
- * system health checks or communication with an appropriate backend team can be organized in response.
- * Please note that this should NOT be used to handler general server-side failures; please see AlAPIServerError
- * for that error condition.
- *
- * @param message - Descriptive error text
- * @param data - a reference to the data that is invalid
- * @param schemaId - The top level schema that was used to validate the data
- * @param validationErrors - Unstructured information about specific response validation issues
- * @param request - A reference to the request from which the data was retrieved (if applicable)
- */
-export class AlDataValidationError extends AlBaseError
-{
     constructor( message:string,
-                 public data:unknown,
-                 public schemaId:string,
-                 public validationErrors:any[] = [],
-                 public request?:AxiosRequestConfig ) {
+                 public invalidResponse:AxiosResponse,
+                 public validationErrors:any[] = [] ) {
         /* istanbul ignore next */
         super( message );
     }

--- a/src/common/forms/types.ts
+++ b/src/common/forms/types.ts
@@ -1,6 +1,6 @@
 export interface AlDynamicFormControlElementOptions {
     label: string;
-    value: string | undefined;
+    value: string;
     disabled?: boolean;
 }
 

--- a/src/common/locator/al-route.types.ts
+++ b/src/common/locator/al-route.types.ts
@@ -240,7 +240,24 @@ export class AlRoute {
     }
 
     public static link( host:AlRoutingHost, locationId:string, path:string, caption:string = "Link" ) {
-        return new AlRoute( host, { caption: caption, action: { type: "link", location: locationId, path: path }, properties: {} } );
+        return new AlRoute( host, {
+            caption,
+            action: {
+                type: "link",
+                location: locationId,
+                path: path
+            },
+            properties: {} } );
+    }
+
+    public static trigger( host:AlRoutingHost, triggerName:string, caption:string = "Trigger" ) {
+        return new AlRoute( host, {
+            caption,
+            action: {
+                type: "trigger",
+                trigger: triggerName
+            },
+            properties: {} } );
     }
 
     /**

--- a/src/common/utility/al-validation.types.ts
+++ b/src/common/utility/al-validation.types.ts
@@ -1,0 +1,91 @@
+import { getJsonPath } from './json-utilities';
+import { AlDataValidationError } from '../errors/al-error.types';
+import * as tv4 from 'tv4';
+
+/**
+ * Provides an interface for API clients or other services that can provide validation schemas.
+ * A validation schema is just a JSON object describing a data structure according to the JSON Schema
+ * v4 specification.
+ */
+export interface AlValidationSchemaProvider {
+    hasSchema: ( schemaId:string ) => boolean;
+    getSchema: ( schemaId:string ) => Promise<any>;
+    getProviders?: () => AlValidationSchemaProvider[];
+}
+
+interface TV4Error {
+    code:number;
+    message: string;
+    dataPath: string;
+    schemaPath: string;
+}
+
+export interface AlValidationResponse {
+    valid: boolean;
+    error?: TV4Error;
+    missing?: string[];
+}
+
+/**
+ * The workhorse class that actually performs validation.
+ */
+export class AlJsonValidator {
+
+    protected static validationApi:any;
+
+    protected providers:AlValidationSchemaProvider[] = [];
+
+    constructor( ...initialProviders:AlValidationSchemaProvider[] ) {
+        this.addProviders( ...initialProviders );
+        if ( ! AlJsonValidator.validationApi ) {
+            AlJsonValidator.validationApi = tv4.freshApi();
+        }
+    }
+
+    public async test( target:any, schemaId:string ):Promise<AlValidationResponse> {
+        let [ baseSchemaId, definitionId ] = schemaId.split("#");
+        let schema = await this.findSchema( baseSchemaId );
+        if ( definitionId ) {
+            schema = getJsonPath( schema, definitionId.replace( /\//g, "." ) );
+            if ( ! schema ) {
+                throw new Error( `The schema '${baseSchemaId}' does not contain a definition at path '${definitionId}'` );
+            }
+        }
+        let result = AlJsonValidator.validationApi.validateResult( target, schema, true, false ) as AlValidationResponse;
+        return result;
+    }
+
+    /**
+     * Adds a single schema provider to the list of registered providers
+     */
+    public addProvider( provider:AlValidationSchemaProvider ) {
+        this.providers.push( provider );
+        if ( 'getProviders' in provider ) {
+            this.addProviders( ...provider.getProviders() );
+        }
+    }
+
+    /**
+     * Adds multiple schema providers to the list of registered providers
+     */
+    public addProviders( ...providers:AlValidationSchemaProvider[] ) {
+        providers.forEach( provider => this.addProvider( provider ) );
+    }
+
+    /**
+     * Retrieves a schema from a schema provider.
+     */
+    protected async findSchema( schemaId:string ):Promise<any> {
+        let originProvider = this.providers.find( provider => provider.hasSchema( schemaId ) );
+        if ( ! originProvider ) {
+            throw new Error(`Required schema '${schemaId}' could not be found.` );
+        }
+        let schema = await originProvider.getSchema( schemaId );
+        AlJsonValidator.validationApi.addSchema( schemaId, schema );
+        let missing = AlJsonValidator.validationApi.getMissingUris() as string[];
+        if ( missing && missing.length ) {
+            await Promise.all( missing.map( missingSchemaId => this.findSchema( missingSchemaId ) ) );  //  economical, no?
+        }
+        return schema;
+    }
+}

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -3,6 +3,7 @@ export * from "./al-globalizer";
 export * from "./al-query-evaluator.types";
 export * from "./al-stopwatch";
 export * from "./al-trigger.types";
+export * from './al-validation.types';
 export * from "./is-promise-like";
 export * from "./json-utilities";
 export * from './al-merge-helper';

--- a/src/configuration/al-runtime-configuration.ts
+++ b/src/configuration/al-runtime-configuration.ts
@@ -43,7 +43,8 @@ export enum ConfigOption {
     NavigationViaConduit        = "navigation_use_conduit",
     NavigationViaGestalt        = "navigation_use_gestalt",
     NavigationAssetPath         = "navigation_asset_path",
-    NavigationDefaultAuthState  = "navigation_default_authentication"
+    NavigationDefaultAuthState  = "navigation_default_authentication",
+    NavigationIntegratedAuth    = "navigation_use_integrated_auth"
 }
 
 /**

--- a/src/session/utilities/al-session-detector.ts
+++ b/src/session/utilities/al-session-detector.ts
@@ -156,7 +156,7 @@ export class AlSessionDetector
         if ( environment === 'development' ) {
             environment = 'integration';
         }
-        let sessionStatusURL = AlLocatorService.resolveURL( AlLocation.AccountsUI, `session/v1/status`, { residency, environment } );
+        let sessionStatusURL = AlLocatorService.resolveURL( AlLocation.AccountsUI, `/session/v1/status`, { residency, environment } );
         let sessionStatus = await AlDefaultClient.get( {
             url: sessionStatusURL,
             withCredentials: true

--- a/test/common/al-errors.spec.ts
+++ b/test/common/al-errors.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import * as sinon from 'sinon';
+import { AxiosRequestConfig } from 'axios';
 import {
     AlAPIServerError,
     AlBadGatewayError,
     AlBadRequestError,
     AlNotFoundError,
-    AlResponseValidationError,
+    AlDataValidationError,
     AlUnauthenticatedRequestError,
     AlUnauthorizedRequestError,
     AlUnimplementedMethodError,
@@ -28,19 +29,15 @@ describe( `Errors`, () => {
 
     } );
 
-    describe( 'AlResponseValidationError', () => {
+    describe( 'AlDataValidationError', () => {
         it( 'should instantiate as expected', () => {
-            const error = new AlResponseValidationError( "Some error happened somewhere, somehow", [ { error: true, file: '/file1', line: 120 } ] );
+            let requestConfig = {} as AxiosRequestConfig;
+            let data = {} as unknown;
+            const error = new AlDataValidationError( "Some error happened somewhere, somehow", data, 'https://something#definitions/something-else', [ { thing: true } ], requestConfig );
 
             expect( error.message ).to.be.a("string" );
-            expect( error.errors ).to.be.an("array");
-            expect( error.errors.length ).to.equal( 1 );
-
-            const error2 = new AlResponseValidationError( "Blahblahblah" );
-
-            expect( error2.message ).to.be.a("string" );
-            expect( error2.errors ).to.be.an("array");
-            expect( error2.errors.length ).to.equal( 0 );
+            expect( error.validationErrors ).to.be.an("array");
+            expect( error.validationErrors.length ).to.equal( 1 );
         } );
     } );
 

--- a/test/common/al-validation.spec.ts
+++ b/test/common/al-validation.spec.ts
@@ -1,0 +1,175 @@
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { AlValidationSchemaProvider, AlJsonValidator } from '@al/core';
+
+describe( 'AlJsonValidator', () => {
+
+    let implicitProvider:AlValidationSchemaProvider = {
+        hasSchema: ( schemaId:string ) => {
+            if ( schemaId === 'https://alertlogic.com/fake/types/common.json' ) {
+                return true;
+            }
+            return false;
+        },
+        getSchema: async ( schemaId:string ) => {
+            if ( schemaId === 'https://alertlogic.com/fake/types/common.json' ) {
+                return {
+                    "$id": "https://alertlogic.com/fake/types/common.json",
+                    "definitions": {
+                        "widget": {
+                            "type": "object",
+                            "properties": {
+                                "widget_type": { "type": "string" },
+                                "name": { "type": "string" },
+                                "enabled": { "type": "boolean" },
+                                "subwidgets": {
+                                    "type": "array",
+                                    "items": { "$ref": "#definitions/widget" },
+                                    "default": []
+                                }
+                            },
+                            "required": [ "widget_type", "name" ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object"
+                };
+            }
+            throw new Error("Sorry, bad juju" );
+        }
+    };
+
+    let fakeProvider:AlValidationSchemaProvider = {
+        hasSchema: ( schemaId:string ) => {
+            if ( schemaId === 'https://alertlogic.com/fake/types/thingy.json' ) {
+                return true;
+            }
+            return false;
+        },
+        getSchema: async ( schemaId:string ) => {
+            if ( schemaId === 'https://alertlogic.com/fake/types/thingy.json' ) {
+                return {
+                    "$id": "https://alertlogic.com/fake/types/thingy.json",
+                    "definitions": {
+                        "subthingy": {
+                            "type": "object",
+                            "properties": {
+                                "subthingy_id": { "type": "string", "description": "Sub Thingy Identifier" },
+                                "name":         { "type": "string", "description": "Name of the Sub Thingy" }
+                            },
+                            "required": [ "subthingy_id", "name" ]
+                        }
+                    },
+                    "type": "object",
+                    "properties": {
+                        "type": { "type": "string" },
+                        "widgets": {
+                            "type": "array",
+                            "items": { "$ref": "https://alertlogic.com/fake/types/common.json#definitions/widget" },
+                            "default": []
+                        },
+                        "subthing": { "$ref": "#definitions/subthingy" }
+                    },
+                    "required": [ "type", "widgets" ]
+                };
+            }
+        },
+        getProviders: () => {
+            return [ implicitProvider ];
+        }
+    };
+
+    describe('basic functionality', () => {
+        it('should "just work"', async () => {
+            let validator:AlJsonValidator = new AlJsonValidator( fakeProvider );
+
+            let widget1 = {
+                "widget_type": "mcbobbert",
+                "name": "Big McBobbert"
+            };
+            let widget2 = {
+                "widget_type": "mini_bob",
+                "name": "Mini McBobbert"
+            };
+            let widget3 = {
+                "widget_type": "macro_bob",
+                "name": "Macro Bobbert"
+            };
+            let widget4 = {
+                "widget_type": "parent widget",
+                "name": "A nested widget",
+                "subwidget": widget3
+            };
+            let broken_widget1 = {
+                "widget_type": "broken1"        //  missing name, a required property
+            };
+            let broken_widget2 = {
+                "widget_type": 2,               //  invalid numeric ID
+                "name": "Something",
+                "enabled": true
+            };
+            let broken_widget3 = {
+                "widget_type": "broken3",
+                "name": "broken",
+                "enabledd": true                //  misspelled property
+            };
+            let data1 = {
+                "type": "mcthingy",
+                "widgets": [ widget1, widget2, widget3, widget4 ]
+            };
+
+            let data2 = {
+                "type": 1,
+                "widgets": [ "one", "two", "three" ]
+            };
+            let result = await validator.test( data1, "https://alertlogic.com/fake/types/thingy.json" );
+            expect( result.valid ).to.equal( true );
+
+            result = await validator.test( data2, "https://alertlogic.com/fake/types/thingy.json" );
+            expect( result.valid ).to.equal( false );
+
+            result = await validator.test( widget1, "https://alertlogic.com/fake/types/common.json#definitions/widget" );
+            expect( result.valid ).to.equal( true );
+
+            result = await validator.test( widget2, "https://alertlogic.com/fake/types/common.json#definitions/widget" );
+            expect( result.valid ).to.equal( true );
+
+            result = await validator.test( widget3, "https://alertlogic.com/fake/types/common.json#definitions/widget" );
+            expect( result.valid ).to.equal( true );
+
+            result = await validator.test( broken_widget1, "https://alertlogic.com/fake/types/common.json#definitions/widget" );
+            expect( result.valid ).to.equal( false );
+
+            result = await validator.test( broken_widget2, "https://alertlogic.com/fake/types/common.json#definitions/widget" );
+            expect( result.valid ).to.equal( false );
+
+            result = await validator.test( broken_widget3, "https://alertlogic.com/fake/types/common.json#definitions/widget" );
+            expect( result.valid ).to.equal( false );
+        } );
+    } );
+
+    describe( "error cases", () => {
+        describe("missing schemas", () => {
+            it("should be handled gracefully", async () => {
+                try {
+                    let validator:AlJsonValidator = new AlJsonValidator( fakeProvider );
+                    await validator.test( {}, "https://alertlogic.com/fake/types/missing.json" );
+                    expect( true ).to.equal( false );
+                } catch( e ) {
+                    expect( e instanceof Error ).to.equal( true );
+                }
+            } );
+        } );
+        describe("missing schema definition", () => {
+            it("should be handled gracefully", async () => {
+                try {
+                    let validator:AlJsonValidator = new AlJsonValidator( fakeProvider );
+                    await validator.test( {}, "https://alertlogic.com/fake/types/common.json#definitions/missing" );
+                    expect( true ).to.equal( false );
+                } catch( e ) {
+                    expect( e instanceof Error ).to.equal( true );
+                }
+            } );
+        } );
+    } );
+} );

--- a/test/session/al-session-detector.spec.ts
+++ b/test/session/al-session-detector.spec.ts
@@ -196,32 +196,26 @@ describe('AlSessionDetector', () => {
 
     describe("detectSession()", () => {
         describe("with a local session", () => {
-            it( "should resolve true", ( done ) => {
+            it( "should resolve true", async () => {
                 AlSession.deactivateSession();
-                AlSession.setAuthentication( exampleSession );
-                sessionDetector.detectSession().then( result => {
-                    expect( result ).to.equal( true );
-                    expect( sessionDetector.authenticated ).to.equal( true );
-                    sessionDetector.onDetectionFail( () => {} );      //  kill the promise
-                    done();
-                } );
+                await AlSession.setAuthentication( exampleSession );
+                let result = await sessionDetector.detectSession();
+                expect( result ).to.equal( true );
+                expect( sessionDetector.authenticated ).to.equal( true );
+                sessionDetector.onDetectionFail( () => {} );      //  kill the promise
             } );
         } );
 
         describe("with a gestalt session", () => {
-            it( "should resolve true", ( done ) => {
+            it( "should resolve true", async () => {
                 AlRuntimeConfiguration.setOption( ConfigOption.GestaltAuthenticate, true );
                 AlSession.deactivateSession();
                 sinon.stub( sessionDetector, 'getGestaltSession' ).returns( Promise.resolve( exampleSession ) );
                 sinon.stub( sessionDetector, 'ingestExistingSession' ).returns( Promise.resolve( true ) );
-                sessionDetector.detectSession().then( result => {
-                    expect( result ).to.equal( true );
-                    expect( sessionDetector.authenticated ).to.equal( true );
-                    sessionDetector.onDetectionFail( () => {} );      //  kill the promise
-                    done();
-                }, error => {
-                    expect( "Shouldn't get a promise rejection!").to.equal( false );
-                } );
+                let result = await sessionDetector.detectSession();
+                expect( result ).to.equal( true );
+                expect( sessionDetector.authenticated ).to.equal( true );
+                sessionDetector.onDetectionFail( () => {} );      //  kill the promise
             } );
         } );
 
@@ -244,7 +238,7 @@ describe('AlSessionDetector', () => {
         describe("with an auth0 session", () => {
             it( "should resolve true", ( done ) => {
                 AlSession.deactivateSession();
-                AlRuntimeConfiguration.setOption( ConfigOption.GestaltAuthenticate, true );
+                AlRuntimeConfiguration.setOption( ConfigOption.GestaltAuthenticate, false );
 
                 let auth0AuthStub = sinon.stub( sessionDetector, 'getAuth0Authenticator' ).returns( <WebAuth><unknown>{
                     checkSession: ( config, callback ) => {


### PR DESCRIPTION
- Added tv4 dependency.
- Added AlJsonValidator utility class, which does the work of resolving
  dependent schemas and invoking tv4.
- Added support in AlDefaultClient for validation response against a
  given schema, from a given set of providers.
- Added default schema providers for limited AIMS and common types.
- Added unit tests, and fixed some broken ones that never should have
  worked in the first place.
- Ground my teeth to nubs
- Bumped version to 1.0.90