### PR TITLE
ENG-0000 - Fix defect when authenticating via AIMS Token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.94",
+  "version": "1.0.95",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -168,6 +168,7 @@ export class AlSessionInstance
 
     public async authenticateWithAccessToken( accessToken:string, options:{actingAccount?:string|AIMSAccount,locationId?:string} = {} ):Promise<boolean> {
       let tokenInfo = await AIMSClient.getTokenInfo( accessToken );
+      tokenInfo.token = accessToken; // Annoyingly, AIMS does not include the `token` property in its response to this call, making the descriptor somewhat irregular
       await this.setAuthentication( { authentication: tokenInfo }, options );
       return true;
     }


### PR DESCRIPTION
AlSession exposes three different authentication methods --
username/password, session token/mfa verification code, and token -- and
there is a longstanding bug that prevents the token variant from working
properly.  At long last, that bug is squished.