### PR TITLE
ENG-0000 - Support Primary/Inert Activation Modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.100",
+  "version": "1.0.101",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Adds a property to route definitions that allows the schema to indicate
which instance of a given route should be activated when there are
multiple possible matches.

In practice, this satisfies a need created by the Notifications/v4
feature, which has multiple routes referring to the same locations in
console.account.