### PR TITLE
ENG-0000 - endpoint handling refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.95",
+  "version": "1.1.0-beta.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,7 +1,6 @@
 export { APIRequestParams } from './types';
 export * from './events';
 export {
-    AlEndpointsServiceCollection,
     AlApiClient,
     AlDefaultClient,
     AlDefaultClient as ALClient    /* @deprecated */

--- a/src/common/navigation/al-locator.types.ts
+++ b/src/common/navigation/al-locator.types.ts
@@ -263,6 +263,13 @@ export class AlLocatorMatrix
     }
 
     /**
+     * Retrieves the current residency (US or EMEA)
+     */
+    public getCurrentResidency():string {
+        return this.context.residency || "US";
+    }
+
+    /**
      * Arguably the only important general-purpose functionality of this service.
      * Calculates a URL from a location identifier, an optional path fragment, and an optional context.
      *

--- a/src/common/utility/al-mutex.ts
+++ b/src/common/utility/al-mutex.ts
@@ -1,0 +1,44 @@
+/**
+ *  An extremely simple mutual-exclusion mechanism for asynconrous activities.
+ *  Only one operation can execute at a given time; subsequent operations will be triggered when their predecessors resolve, reject, or error.
+ *  Each invocation of `run` returns a promise that will resolve when that particular action has finished executing (unless an error is
+ *  caught), and will pass through the return value of the inner function.
+ *  Rejection will not cancel the execution sequence, as in traditional promise chains.
+ */
+
+export class AlMutex {
+    protected queue:{
+        action: {():Promise<any>},
+        resolve: {(v:any):void},
+        reject: {(e:any):void}
+    }[] = [];
+    protected running?:Promise<any>;
+
+    /**
+     * This is the only exposed method of a mutex instance.
+     */
+    public run<ReturnType=any>( action:{():Promise<ReturnType>} ):Promise<ReturnType> {
+        return new Promise<ReturnType>( ( resolve, reject ) => {
+            if ( this.running ) {
+                this.queue.push( { action, resolve, reject } );
+            } else {
+                this.running = this.exec( action, resolve, reject );
+            }
+        } );
+    }
+
+    protected async exec( action:{():Promise<any>}, resolve:{(value:any):void}, reject:{(error:any):void} ) {
+        action().then( r => resolve( r ), e => reject( e ) )
+                .catch( e => console.warn( `Ignoring an unhandled error inside a mutex callback`, e ) )
+                .finally( () => this.execNext() );
+    }
+
+    protected execNext() {
+        if ( this.queue.length === 0 ) {
+            this.running = undefined;
+        } else {
+            let { action, resolve, reject } = this.queue.shift();
+            this.running = this.exec( action, resolve, reject );
+        }
+    }
+}

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -8,3 +8,4 @@ export * from "./is-promise-like";
 export * from "./json-utilities";
 export * from './al-merge-helper';
 export * from './timezone-utilities';
+export * from './al-mutex';

--- a/src/session/types/types.ts
+++ b/src/session/types/types.ts
@@ -1,4 +1,3 @@
-import { AlEndpointsServiceCollection } from "../../client";
 import {
     AIMSAccount,
     AIMSUser,
@@ -12,7 +11,7 @@ export interface AlConsolidatedAccountMetadata {
     managedAccounts?:AIMSAccount[];
     primaryEntitlements:AlEntitlementRecord[];
     effectiveEntitlements:AlEntitlementRecord[];
-    endpointsData:AlEndpointsServiceCollection;
+    endpointsData:any;
 }
 
 export interface AlSessionProfile {

--- a/test/client/al-api-client.spec.ts
+++ b/test/client/al-api-client.spec.ts
@@ -52,26 +52,37 @@ const defaultAuthResponse = {
 beforeEach(() => {
     xhrMock.setup();
     AlLocatorService.setContext( { environment: "integration", residency: 'EMEA', insightLocationId: 'defender-uk-newport' } );      //  for unit tests, assume integration environment
-    ALClient['endpointResolution']["integration"] = {};
-    ALClient['endpointResolution']["integration"]["0"] = Promise.resolve( {
-      "cargo": { "default" : "https://api.global-integration.product.dev.alertlogic.com" },
-      "kevin": { "default" : "https://kevin.product.dev.alertlogic.com" },
-      'search': { "default" : "https://api.global-fake-integration.product.dev.alertlogic.com" },
-      "aims": { "default" : "https://api.global-integration.product.dev.alertlogic.com" }
-    } );
-    ALClient['endpointResolution']["integration"]["2"] = ALClient['endpointResolution']["integration"][0];
-    ALClient['endpointResolution']["integration"]["3"] = Promise.resolve( {
-      "cargo": { "default" : "https://api.global-integration.product.dev.alertlogic.com" },
-      "kevin": { "default" : "https://kevin.product.dev.alertlogic.co.uk" }
-    } );
-    ALClient['endpointResolution']["integration"]["67108880"] = ALClient['endpointResolution']["integration"][0];
-    ALClient['endpointResolution']["integration"]["1234567"] = Promise.resolve( {
-        "iris": {
-            "EMEA" : {
-                "defender-uk-newport" : "https://rob.product.dev.alertlogic.co.uk"
+    ALClient['endpointCache'] = {
+        'integration': {
+            "0": {
+                "cargo": { "default": "https://api.global-integration.product.dev.alertlogic.com" },
+                "kevin": { "default" : "https://kevin.product.dev.alertlogic.com" },
+                "search": { "default" : "https://api.global-fake-integration.product.dev.alertlogic.com" },
+                "aims": { "default" : "https://api.global-integration.product.dev.alertlogic.com" }
+            },
+            "2": {
+                "cargo": { "default": "https://api.global-integration.product.dev.alertlogic.com" },
+                "kevin": { "default" : "https://kevin.product.dev.alertlogic.com" },
+                "search": { "default" : "https://api.global-fake-integration.product.dev.alertlogic.com" },
+                "aims": { "default" : "https://api.global-integration.product.dev.alertlogic.com" }
+            },
+            "3": {
+              "cargo": { "default" : "https://api.global-integration.product.dev.alertlogic.com" },
+              "kevin": { "default" : "https://kevin.product.dev.alertlogic.co.uk" }
+            },
+            "67108880": {
+                "cargo": { "default": "https://api.global-integration.product.dev.alertlogic.com" },
+                "kevin": { "default" : "https://kevin.product.dev.alertlogic.com" },
+                "search": { "default" : "https://api.global-fake-integration.product.dev.alertlogic.com" },
+                "aims": { "default" : "https://api.global-integration.product.dev.alertlogic.com" }
+            },
+            "1234567": {
+                "iris": {
+                    "EMEA": "https://rob.product.dev.alertlogic.co.uk"
+                }
             }
         }
-      } );
+    };
 } );
 afterEach(() => {
   xhrMock.teardown();


### PR DESCRIPTION
- Adds a simple promise-driven mutex class
- Use mutexes to enforce one endpoint lookup at a time
- Divided handling of default and residency-aware endpoint lookups
- Refactored to use native async/await more gracefully
- Totally replaced the way that endpoint dictionary is cached