### PR TITLE
ENG-0000 - Tweaked AlSession.ready()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.114",
+  "version": "1.0.115",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Previously, this method only resolved as ready after at least one
session detection cycle had been completed.  This could cause a timeout.
The logic has been revised to resolve if either all session detection
cycles are complete or none are in flight.