### PR TITLE
ENG-0000 - Hotpotatofix/v1.0.116

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.115",
+  "version": "1.0.116",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/aims-client/aims-client.ts
+++ b/src/aims-client/aims-client.ts
@@ -120,7 +120,6 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
       version: this.serviceVersion,
       account_id: accountId,
       path: `/users/${userId}`,
-      retry_count: 5,
       ttl: 2 * 60 * 1000
     });
     return userDetails as AIMSUser;
@@ -167,7 +166,6 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
       version: this.serviceVersion,
       account_id: accountId,
       path: '/account',
-      retry_count: 5,
       ttl: 2 * 60 * 1000
     });
     return accountDetails as AIMSAccount;
@@ -211,7 +209,6 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
       account_id: accountId,
       path: `/account_ids/${relationship}`,
       params: queryParams,
-      retry_count: 5,
       ttl: 2 * 60 * 1000
     });
     return accountIds.account_ids as string[];
@@ -233,7 +230,6 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
       account_id: accountId,
       path: `/accounts/${relationship}`,
       params: queryParams,
-      retry_count: 5,
       ttl: 2 * 60 * 1000
     });
     return managedAccounts.accounts as AIMSAccount[];

--- a/src/session/utilities/al-session-detector.ts
+++ b/src/session/utilities/al-session-detector.ts
@@ -16,6 +16,7 @@ import {
 import { AlStopwatch } from "../../common/utility";
 
 import { AlSession } from '../al-session';
+import { AlActingAccountResolvedEvent } from '../events';
 import { AlConduitClient } from './al-conduit-client';
 import { AlRuntimeConfiguration, ConfigOption } from '../../configuration';
 
@@ -37,6 +38,11 @@ export class AlSessionDetector
      */
     protected static cachedA0UserInfo:{[accessKey:string]:any} = {};
 
+    /**
+     * Indicates whether a listener to acting account changes has been attached to AlSession yet
+     */
+    protected static listening = false;
+
     /*----- Public Instance Properties -----------------------
     /**
      *  Indicates whether or not this authentication provider is currently authenticated.
@@ -48,6 +54,12 @@ export class AlSessionDetector
      */
     constructor( public conduit:AlConduitClient,
                  public useAuth0:boolean = true ) {
+        if ( ! AlSessionDetector.listening ) {
+            AlSessionDetector.listening = true;
+            AlSession.notifyStream.attach( AlActingAccountResolvedEvent, ( event:AlActingAccountResolvedEvent ) => {
+                this.conduit.setSession( AlSession.getSession() );
+            } );
+        }
     }
 
     /**

--- a/src/subscriptions-client/types/al-subscription.types.ts
+++ b/src/subscriptions-client/types/al-subscription.types.ts
@@ -162,6 +162,15 @@ export class AlEntitlementCollection
     }
 
     /**
+     * Converts an entitlement collection to an array of entitlement keys
+     */
+    public toArray():string[] {
+        return Object.entries( this.collection )
+                    .filter( ( [ entitlementKey, record ] ) => record.active )
+                    .map( ( [ entitlementKey, record ] ) => entitlementKey );
+    }
+
+    /**
      *  Merges a set of entitlement records into the collection, using the following rules:
      *      -   Active entitlements for a given product supersede inactive entitlements
      *      -   Latest active expiration supercedes earlier expirations


### PR DESCRIPTION
Fixes state ambiguity during application bootstrap.

  - Restoration of session state during AlSession constructor is *no
longer delayed* using setTimeout.  This was allowing session detection
to start before the state could be reconstituted.
  - Restoration of session state from local/persisted data now blocks
session detection -- no more overlapping calls to `setActingAccount()`
  - Session detector tracks changes to the acting account and
synchronizes them to conduit's stored session

Also a few nice to haves:

  - Removed `retry_count` from AIMS and subscriptions calls; they just
    aren't useful.
  - Added a `toArray()` utility method to `AlEntitlementCollection`
  - Captured complete AxiosResponse in lastError when an error occurs