### PR TITLE
ENG-0000 - Session Idle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.127",
+  "version": "1.0.128",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/aims-client/aims-client.ts
+++ b/src/aims-client/aims-client.ts
@@ -278,6 +278,25 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
   }
 
   /**
+   * Update account session idle expiration
+   * POST
+   * This updates a single property of an AIMS account record, affecting how long users of that account
+   * can be idle before their sessions will be terminated due to inactivity.
+   */
+  async setAccountIdleThreshold( accountId:string, seconds:number ) {
+    await this.client.post( {
+      service_stack: AlLocation.GlobalAPI,
+      service_name: this.serviceName,
+      version: this.serviceVersion,
+      account_id: accountId,
+      path: '/account',
+      data: {
+        idle_session_timeout: seconds
+      }
+    } );
+  }
+
+  /**
    * Authenticate a user's identity
    * POST
    * /aims/v1/authenticate

--- a/src/session/utilities/al-session-detector.ts
+++ b/src/session/utilities/al-session-detector.ts
@@ -135,19 +135,23 @@ export class AlSessionDetector
         if ( this.useAuth0 ) {
             try {
                 let authenticator   =   this.getAuth0Authenticator();
-                let config          =   this.getAuth0Config( { usePostMessage: true, prompt: 'none' } );
-                let accessToken     =   await this.getAuth0SessionToken( authenticator, config, 5000 );
-                let tokenInfo       =   await AIMSClient.getTokenInfo( accessToken );
+                if ( authenticator ) {
+                    let config          =   this.getAuth0Config( { usePostMessage: true, prompt: 'none' } );
+                    let accessToken     =   await this.getAuth0SessionToken( authenticator, config, 5000 );
+                    let tokenInfo       =   await AIMSClient.getTokenInfo( accessToken );
 
-                /**
-                 * The following rather obscure assignment is necessary because aims' token_info endpoint responds with the complete token information *except* the token itself
-                 */
-                session = {
-                    authentication: Object.assign({}, tokenInfo, {token: accessToken})
-                };
+                    /**
+                     * The following rather obscure assignment is necessary because aims' token_info endpoint responds with the complete token information *except* the token itself
+                     */
+                    session = {
+                        authentication: Object.assign({}, tokenInfo, {token: accessToken})
+                    };
 
-                await this.ingestExistingSession( session );
-                this.onDetectionSuccess( resolve );
+                    await this.ingestExistingSession( session );
+                    this.onDetectionSuccess( resolve );
+                } else {
+                    return this.onDetectionFail( resolve, `auth0 is not installed` );
+                }
             } catch( e ) {
                 let error = AlErrorHandler.normalize( e );
                 return this.onDetectionFail( resolve, `Failed to detect/ingest auth0 session: ${error.message}` );


### PR DESCRIPTION
Added a method to AIMSClient to allow setting the session idle threshold.

Also fixed a condition (that mostly effected the design library's
playground application) where a nasty error prints out if auth0 isn't
found.