### PR TITLE
ENG-0000 - Fix Expired Token Retention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.131",
+  "version": "1.0.132",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/utilities/al-authentication.utility.ts
+++ b/src/session/utilities/al-authentication.utility.ts
@@ -112,6 +112,7 @@ export class AlAuthenticationUtility {
                 return this.state.result;
             }
         }
+        this.state.result = AlAuthenticationResult.InvalidCredentials;
         return this.state.result;
     }
 

--- a/src/session/utilities/al-conduit-client.ts
+++ b/src/session/utilities/al-conduit-client.ts
@@ -124,11 +124,14 @@ export class AlConduitClient
     }
 
     /**
-     * Sets session information TO the conduit.  Should always resolve with a copy of the session information.
+     * Sets session information TO the conduit.  Should always resolve with a copy of the session (including acting
+     * account and active datacenter) that conduit considers most fresh.  Note that in rare cases this may
+     * deviate from the session provided to this method, in which case the caller should update its data to reflect
+     * conduit's.
      */
-    public setSession(sessionData: AIMSSessionDescriptor): Promise<AIMSSessionDescriptor> {
-        return this.request('conduit.setSession', { session: sessionData })
-                    .then( rawResponse => rawResponse.session as AIMSSessionDescriptor );
+    public async setSession(sessionData: AIMSSessionDescriptor): Promise<AIMSSessionDescriptor> {
+        let result = await this.request( 'conduit.setSession', { session: sessionData } );
+        return result.session;
     }
 
     /**

--- a/test/session/al-session-detector.spec.ts
+++ b/test/session/al-session-detector.spec.ts
@@ -211,6 +211,7 @@ describe('AlSessionDetector', () => {
             it( "should resolve true", async () => {
                 AlRuntimeConfiguration.setOption( ConfigOption.GestaltAuthenticate, true );
                 AlSession.deactivateSession();
+                sinon.stub( conduit, 'getSession' ).returns( Promise.resolve( null ) );
                 sinon.stub( sessionDetector, 'getGestaltSession' ).returns( Promise.resolve( exampleSession ) );
                 sinon.stub( sessionDetector, 'ingestExistingSession' ).returns( Promise.resolve( true ) );
                 let result = await sessionDetector.detectSession();


### PR DESCRIPTION
Added logic to session detection to
    1.  Query conduit for a session before querying gestalt or auth0
    2.  Detect when conduit responds with a different token, and apply
it to the current session.
    3.  Bumped version to 1.0.32

The intention here is to guarantee that the newest authentication token
is always propagated, and older ones are not persisted.