### PR TITLE
ENG-0000 - Session Detection Promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.132",
+  "version": "1.0.133",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/utilities/al-session-detector.ts
+++ b/src/session/utilities/al-session-detector.ts
@@ -92,6 +92,19 @@ export class AlSessionDetector
     }
 
     /**
+     * Returns a promise that either resolves immediately (if no session detection is in process) or resolves after
+     * an in-progress detection cycle has completed.  This allows the caller to wait for detection to finish without
+     * starting an unwanted detection cycle.
+     */
+
+    public async detectionComplete():Promise<boolean> {
+        if ( AlSessionDetector.detectionPromise ) {
+            await AlSessionDetector.detectionPromise;
+        }
+        return AlSession.isActive();
+    }
+
+    /**
      *  Imperatively forces the user to authenticate.
      */
 


### PR DESCRIPTION
Adds a `detectionComplete` method to AlSessionDetector, allowing a
caller to wait for session detection to finish without starting a
detection cycle.