### PR TITLE
ENG-0000/VTT-3207 - Authentication Without Roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.133",
+  "version": "1.0.134",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -21,6 +21,7 @@ import {
     AlDefaultClient,
 } from "../client";
 import { AlDataValidationError } from "../common/errors";
+import { AlErrorHandler } from '../error-handler';
 import {
     AlInsightLocations,
     AlLocation,
@@ -225,6 +226,7 @@ export class AlSessionInstance
             this.sessionData.boundLocationId = proposal.boundLocationId;
         }
         this.activateSession();
+
         let result:AlActingAccountResolvedEvent = proposal.acting
                                                   ? await this.setActingAccount( proposal.acting, proposal.profileId )
                                                   : await this.setActingAccount( proposal.authentication.account, proposal.profileId );
@@ -232,6 +234,8 @@ export class AlSessionInstance
         this.storage.set("session", this.sessionData );
         return result;
       } catch( e ) {
+        AlErrorHandler.log( e, `AlSession.setAuthentication() failed` );
+        this.deactivateSession();
         throw e;
       } finally {
         this.endDetection();

--- a/src/session/utilities/al-authentication.utility.ts
+++ b/src/session/utilities/al-authentication.utility.ts
@@ -13,6 +13,7 @@ export enum AlAuthenticationResult {
     Unauthenticated         = 'unauthenticated',
     Authenticated           = 'authenticated',
     AccountLocked           = 'account_locked',
+    AccountUnavailable      = 'account_unavailable',
     PasswordResetRequired   = 'password_expired',
     MFAEnrollmentRequired   = 'mfa_enrollment_required',
     MFAVerificationRequired = 'mfa_verification_required',
@@ -198,11 +199,14 @@ export class AlAuthenticationUtility {
             } else if ( this.requiresTOSAcceptance( error ) ) {
                 this.state.result = AlAuthenticationResult.TOSAcceptanceRequired;
                 this.state.termsOfServiceURL = getJsonPath<string>( error, 'data.tos_url', null );
+            } else if( error.status === 400) {
+                this.state.result = AlAuthenticationResult.AccountLocked;
+                return true;
             } else if ( error.status === 401 ) {
                 this.state.result = AlAuthenticationResult.InvalidCredentials;
                 return true;
-            } else if( error.status === 400) {
-                this.state.result = AlAuthenticationResult.AccountLocked;
+            } else if ( error.status === 403 ) {
+                this.state.result = AlAuthenticationResult.AccountUnavailable;
                 return true;
             }
             /**

--- a/src/subscriptions-client/subscriptions-client.ts
+++ b/src/subscriptions-client/subscriptions-client.ts
@@ -39,7 +39,6 @@ export class AlSubscriptionsClient {
       account_id: accountId,
       path: '/entitlements',
       params: queryParams,
-      retry_count: 5,
       ttl: 5 * 60 * 1000    /* 5 minute in-memory caching */
     });
     return entitlements;


### PR DESCRIPTION
Adds more graceful handling for cases where authentication succeeds but
account resolution does not.  In practice, this case concerns a user
account without any roles: authentication succeeds, but both
subscriptions/entitlements and aims/accounts lookups return a 403.

Also, removes retry from subscriptions/v1/entitlements endpoint.

VTT case here: https://alertlogic.atlassian.net/browse/VTT-3207