### PR TITLE
ENG-28315 - Normalize XHRHttpRequest.withCredentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.135",
+  "version": "1.0.136",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -485,7 +485,8 @@ export class AlApiClient implements AlValidationSchemaProvider
       headers: {
         Authorization: `Basic ${this.base64Encode(`${user}:${pass}`)}`
       },
-      data: payload
+      data: payload,
+      withCredentials: true
     });
   }
 
@@ -525,7 +526,8 @@ export class AlApiClient implements AlValidationSchemaProvider
       },
       data: {
         mfa_code: mfa_code
-      }
+      },
+      withCredentials: true
     } );
   }
 
@@ -553,7 +555,8 @@ export class AlApiClient implements AlValidationSchemaProvider
       },
       data: {
         accept_tos: true
-      }
+      },
+      withCredentials: true
     } );
   }
 
@@ -876,7 +879,7 @@ export class AlApiClient implements AlValidationSchemaProvider
 
     this.instance = axios.create({
       timeout: 0,
-      withCredentials: true,
+      withCredentials: false,
       headers: headers,
       paramsSerializer: params => this.normalizeQueryParams(params).replace('?','')
     });

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -774,7 +774,8 @@ export class AlSessionInstance
         service_stack: AlLocation.GestaltAPI,
         service_name: undefined,
         version: undefined,
-        path: `/account/v1/${account.id}/metadata`
+        path: `/account/v1/${account.id}/metadata`,
+        withCredentials: false
       };
       try {
         let [ metadata, profile ] = await Promise.all( [


### PR DESCRIPTION
The only API call in the entire IWS stack is the AIMS authenticate call
-- no other API relies on cookies or `Authorization` headers for any of
their work.  Unfortunately, yarp allows Access-Control-Allow-Credentials
for all endpoints, which is *technically* a vulnerability (Red Siege
identified it as a Low Criticality vulnerability, and Platform Services
and I agree it doesn't constite a real active threat).  To get it off of
our audit results, we will update the UI to use
`Access-Control-Allow-Credentials: true` ONLY for authentication
requests, and `Access-Control-Allow-Credentials: false` for all other
requests.  After the UI is fully updated, yarp will be updated to
disable credentials for all but the authentication endpoint.

Updated version to 1.0.136.