### PR TITLE
ENG-0000 - @al/client interceptor for gateway timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.138",
+  "version": "1.0.139",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/errors/al-error.types.ts
+++ b/src/common/errors/al-error.types.ts
@@ -191,6 +191,36 @@ export class AlBadGatewayError extends AlBaseError
 /**
  * @public
  *
+ * Used to indicate that an upstream service is unavailable.
+ */
+export class AlServiceUnavailableError extends AlBaseError
+{
+    public httpResponseCode:number = 503;
+    /* tslint:disable:no-unused-variable */
+    constructor( message:string, public upstreamService:string, public requestDescription:unknown ) {
+        /* istanbul ignore next */
+        super(message);
+    }
+}
+
+/**
+ * @public
+ *
+ * Used to indicate that an upstream service has failed to complete a request in a timely fashion.
+ */
+export class AlGatewayTimeoutError extends AlBaseError
+{
+    public httpResponseCode:number = 504;
+    /* tslint:disable:no-unused-variable */
+    constructor( message:string, public upstreamService:string, public requestDescription:unknown ) {
+        /* istanbul ignore next */
+        super(message);
+    }
+}
+
+/**
+ * @public
+ *
  * Used to indicate that a resource does not exist.
  *
  * @param message - A general description of the error and error context.


### PR DESCRIPTION
Added two exception types, one for 503/service unavailable and one for
504/gateway timeout.

Updated `AlDefaultClient` to recognize timeout errors and convert them
into `AlGatewayTimeoutError` instances.

Bumped version to 1.0.139.