### PR TITLE
ENG-32933 - Return URL Whitelisting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.158",
+  "version": "1.0.159",
   "description": "Nepal Core",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -800,4 +800,4 @@ export class AlSessionInstance
 }
 
 /*  tslint:disable:variable-name */
-export const AlSession = AlGlobalizer.instantiate( "AlSession", () => new AlSessionInstance(), "FATAL ERROR: multiple instances of @al/session are running.  Please sanitizer your dependency graph!" );
+export const AlSession = AlGlobalizer.instantiate( "AlSession", () => new AlSessionInstance(), "FATAL ERROR: multiple instances of @al/session are running.  Please inject sunlight into your dependency graph!" );

--- a/src/session/utilities/al-authentication.utility.ts
+++ b/src/session/utilities/al-authentication.utility.ts
@@ -1,5 +1,6 @@
 import { AlDefaultClient } from '../../client';
 import { AlSession } from '../al-session';
+import { AlLocatorService, AlLocation } from '../../common/navigation';
 import { AIMSSessionDescriptor } from '../../aims-client/types';
 import { AlRuntimeConfiguration, ConfigOption } from '../../configuration';
 import { AlConduitClient } from './al-conduit-client';
@@ -169,6 +170,20 @@ export class AlAuthenticationUtility {
             throw new Error("Invalid usage: no terms of service URL is available." );
         }
         return this.state.termsOfServiceURL;
+    }
+
+    /**
+     * "Normalizes" a return URL -- internally, this merely checks the URL against a whitelist of target domains.
+     */
+    public filterReturnURL( returnURL:string, defaultReturnURL?:string ):string {
+        let validPatterns = [
+            /https?:\/\/[\w\-\.]*alertlogic\.(net|com|co\.uk).*/,
+            /https?:\/\/localhost:.*/
+        ];
+        if ( validPatterns.find( pattern => pattern.test( returnURL ) ) ) {
+            return returnURL;
+        }
+        return defaultReturnURL || AlLocatorService.resolveURL( AlLocation.AccountsUI, `/#/` );
     }
 
     /**

--- a/test/session/al-authentication.utility.spec.ts
+++ b/test/session/al-authentication.utility.spec.ts
@@ -134,4 +134,55 @@ describe('AlAuthenticationUtility', () => {
         } );
     } );
 
+    describe( ".filterReturnURL()", () => {
+        beforeEach( () => {
+            AlSession.deactivateSession();
+            authenticator = new AlAuthenticationUtility( { sessionToken: "MySessionToken" } );
+        } );
+
+        it( "should allow legit internal URLs", () => {
+            let internalURLs = [
+                `https://console.dashboards.alertlogic.com/#/some/silly/path`,
+                `http://console.overview.alertlogic.com`,
+                `https://ng-common-components.ui-dev.product.dev.alertlogic.com`,
+                `https://console.exposures.alertlogic.co.uk/#/blah/2?aaid=2&locid=thppppt`,
+                `https://console.alertlogic.net/events.php`
+            ];
+
+            internalURLs.forEach( url => {
+                let value = authenticator.filterReturnURL( url );
+                expect( value ).to.equal( url );
+            } );
+        } );
+
+        it( "should allow localhost URLs", () => {
+            let localURLs = [
+                `https://localhost:99999/#/dashboards`,
+                `http://localhost:4220/#/search/expert/2?aaid=2&locid=defender-us-denver`
+            ];
+            localURLs.forEach( url => {
+                let value = authenticator.filterReturnURL( url );
+                expect( value ).to.equal( url );
+            } );
+        } );
+
+        it( "should reject external URLs", () => {
+            let externalURLs = [
+                `https://google.com`,
+                `https://console.dashboards.alertlogic.hackery.com/#/some/silly/path`,
+                `https://console.alertlogic-not.com`
+            ];
+
+            externalURLs.forEach( url => {
+                let value = authenticator.filterReturnURL( url );
+                expect( value ).to.equal( `https://console.account.alertlogic.com/#/` );
+            } );
+        } );
+
+        it( "should allow the caller to override the default URL", () => {
+            let result = authenticator.filterReturnURL( `https://google.com`, `https://console.alertlogic.com/#/path` );
+            expect( result ).to.equal( `https://console.alertlogic.com/#/path` );
+        } );
+    } );
+
 } );


### PR DESCRIPTION
Provides a method to filter return/redirection targets, to avoid
exploitability by external players.

Also, fixed a really aggravating typo from 2019.  Grrr.