### PR TITLE
ENG-33432: fix prod uri locations for magma to .com variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.162",
+  "version": "1.0.163",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/navigation/al-locator.types.ts
+++ b/src/common/navigation/al-locator.types.ts
@@ -101,7 +101,7 @@ export class AlLocation
                 locTypeId: locTypeId,
                 environment: 'production',
                 residency: 'EMEA',
-                uri: `https://console.${appCode}.alertlogic.co.uk`,
+                uri: `https://console.${appCode}.alertlogic${locTypeId===AlLocation.MagmaUI ? '.com' : '.co.uk'}`,
                 keyword: appCode
             },
             {
@@ -115,7 +115,7 @@ export class AlLocation
                 locTypeId: locTypeId,
                 environment: 'production-staging',
                 residency: 'EMEA',
-                uri: `https://${appCode}-production-staging-uk.ui-dev.product.dev.alertlogic.com`,
+                uri: `https://${appCode}-production-staging-uk.ui-dev.product.dev.alertlogic${locTypeId===AlLocation.MagmaUI ? '.com' : '.co.uk'}`,
                 keyword: appCode
             },
             {


### PR DESCRIPTION
https://alertlogic.atlassian.net/browse/ENG-33432

- This will ensure no redirect happens in magma when changing residency (between EMEA -> US and vice versa)
  - For both acting account and datacenter (region) selections