### PR TITLE
ENG-0000 - Magma Authentication Proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.169",
+  "version": "1.0.170",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,4 @@
-export { APIRequestParams } from './types';
+export * from './types';
 export * from './events';
 export {
     AlApiClient,

--- a/src/configuration/al-runtime-configuration.ts
+++ b/src/configuration/al-runtime-configuration.ts
@@ -28,6 +28,8 @@ export interface AlParamPreservationRule {
  *   - ConfigOption.GestaltAuthenticate - if true, indicates that AlSession should authenticate via gestalt's session proxy; otherwise,
  *      authentication is performed directly against global AIMS.  Defaults to false.
  *
+ *   - ConfigOption.GestaltDomain - If the GestaltAuthenticate option is enabled, this indicates which application will proxy requests to gestalt.
+ *
  *   - ConfigOption.ResolveAccountMetadata - if true, AlSession's `setActingAccount` method will retrieve metadata (entitlements and account details)
  *      for the primary and acting account before resolving.  Otherwise, `setActingAccount` will resolve immediately.  Defaults to `true`.
  *
@@ -61,6 +63,7 @@ export interface AlParamPreservationRule {
 
 export enum ConfigOption {
     GestaltAuthenticate         = "session_via_gestalt",
+    GestaltDomain               = "session_gestalt_domain",
     ResolveAccountMetadata      = "session_metadata",
     ConsolidatedAccountResolver = "session_consolidated_resolver",
     DisableEndpointsResolution  = "client_disable_endpoints",
@@ -83,6 +86,7 @@ export class AlRuntimeConfiguration {
 
     protected static defaultOptions:{[optionKey:string]:string|number|boolean|unknown} = {
         'session_via_gestalt': false,
+        'session_gestalt_domain': 'cd17:accounts',
         'session_metadata': true,
         'session_consolidated_resolver': false,
         'disable_endpoints_resolution': false,


### PR DESCRIPTION
Added configuration option to allow gestalt session proxying to work
through any application, based on configuration.

Also added a simple interception/error simulation mechanism to our API
Client.  This makes it possible to do something like this:

```
import { AlDefaultClient, randomAPIFailure } from '@al/core';
AlDefaultClient.setInterceptionRules( randomAPIFailure( 10 ) );
```

This will cause 10% of non-session-essential endpoints to fail with a
random error code.  It is also possible to use custom matchers and data,
i.e.,

```
import { AlDefaultClient, randomAPIFailure } from '@al/core';
AlDefaultClient.setInterceptionRules( [
    {
        method: "GET",
        test: /\/applications\/v2\/[0-9]+/something/,
        status: 200,
        data: {
            here: "any mock data you want"
        }
    },
    {
        method: "*",
        test: /\/fake-service\/v1.*/,
        callback: ( response, rule ) => tweakResponse( response )
    }
] );
```

In other words, it can be used to supply mock data or tweak actual
responses to meet certain difficult-to-test criteria.