### PR TITLE
ENG-0000 - Axios Downgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.170",
+  "version": "1.0.176",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -931,11 +931,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.10.0"
       }
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "auth0-js": "^9.16.2",
-    "axios": "^0.21.4",
+    "axios": "^0.21.1",
     "base64-js": "~1.3.0",
     "tv4": "^1.3.0"
   },


### PR DESCRIPTION
Axios versions from 0.21.2 and higher change the way that response
interception promises are wrapped, such that additional tasks are queued
reliably.  Unfortunately, this breaks some of our testing infrastructure
for other projects.