### PR TITLE
ENG-0000: add cargo service to residency aware whitelist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.176",
+  "version": "1.0.178",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.178",
+  "version": "1.0.179",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -78,11 +78,11 @@ export class AlApiClient implements AlValidationSchemaProvider
   /**
    * The following list of services are the ones whose endpoints will be resolved by default.  Added globally/commonly used services here for optimized API performance.
    */
-  protected static defaultServiceList = [ "aims", "subscriptions", "search", "sources", "assets_query", "assets_write", "dashboards", "cargo", "suggestions", "connectors", "herald" ];
+  protected static defaultServiceList = [ "aims", "subscriptions", "search", "sources", "assets_query", "assets_write", "dashboards", "suggestions", "connectors", "herald" ];
   /**
    * The following list of services are the ones whose endpoints will need to be determined for the current context active residency location.
    */
-  protected static resolveByResidencyServiceList = [ "iris", "kalm", "ticketmaster", "tacoma", "responder", "responder-async" ];
+  protected static resolveByResidencyServiceList = [ "iris", "kalm", "ticketmaster", "tacoma", "responder", "responder-async", "cargo" ];
 
   protected static defaultServiceParams: APIRequestParams = {
     service_stack:                  AlLocation.InsightAPI,  //  May also be AlLocation.GlobalAPI, AlLocation.EndpointsAPI, or ALLocation.LegacyUI

--- a/test/client/al-api-client.spec.ts
+++ b/test/client/al-api-client.spec.ts
@@ -149,7 +149,7 @@ describe("AlDefaultClient", () => {
 
           let endpointURL = await AlDefaultClient['calculateRequestURL']({ service_name: 'cargo', service_stack: AlLocation.InsightAPI });
           // path should default to /:service_name/v1, no trailing slash
-          expect(endpointURL).to.equal( "https://api.global-integration.product.dev.alertlogic.com/cargo" );
+          expect(endpointURL).to.equal( "https://api.product.dev.alertlogic.com/cargo" );
 
           endpointURL = await AlDefaultClient['calculateRequestURL']( { service_name: 'aims', version: null, service_stack: AlLocation.InsightAPI } );
           expect(endpointURL).to.equal( "https://api.global-integration.product.dev.alertlogic.com/aims" );
@@ -160,7 +160,7 @@ describe("AlDefaultClient", () => {
 
           endpointURL = await AlDefaultClient['calculateRequestURL']( { service_name: 'cargo', version: 'v2', account_id: '67108880', service_stack: AlLocation.InsightAPI  } );
           //  path should be /:service_name/:version/:accountId, no trailing slash
-          expect( endpointURL ).to.equal( `https://api.global-integration.product.dev.alertlogic.com/cargo/v2/67108880` );
+          expect( endpointURL ).to.equal( `https://api.product.dev.alertlogic.com/cargo/v2/67108880` );
 
           endpointURL = await AlDefaultClient['calculateRequestURL']( { service_name: 'search', version: 'v1', path: 'global-capabilities', service_stack: AlLocation.InsightAPI  } );
           //  domain should be non-default; path should be /:service_name/:version/:path
@@ -519,7 +519,7 @@ describe("AlDefaultClient", () => {
           expect( fullURL ).to.equal( "https://responder.mdr.product.dev.alertlogic.com/v1/12345678/something/wicked?this-way=comes" );
 
           /**
-           * Second test covers URL calculation for MDR APIs WITH endpoints resolution.  MDR APIs should use endpoints data and still not 
+           * Second test covers URL calculation for MDR APIs WITH endpoints resolution.  MDR APIs should use endpoints data and still not
            * introduced the service_name into the path.
            */
           config.noEndpointsResolution = false;
@@ -542,7 +542,7 @@ describe("AlDefaultClient", () => {
         // Testing storage.
         expect(cabinetStorage.get('otherkey')).equal('value3');
         flushSpy = sinon.spy(AlDefaultClient,"flushCacheKeysFromConfig");
-        xhrMock.post('https://api.global-integration.product.dev.alertlogic.com/cargo/v1/2', (req, res) => {
+        xhrMock.post('https://api.product.dev.alertlogic.com/cargo/v1/2', (req, res) => {
           expect(req.method()).to.equal('POST');
           return res.status(200).body({});
         });


### PR DESCRIPTION
Cargo service has recently been updated to be deployed to multiple residencies and so the UI now needs to construct calls to cargo based on the current active residency