### PR TITLE
ENG-0000 - Wildcard Entitlement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.181",
+  "version": "1.0.182",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/subscriptions-client/types/al-subscription.types.ts
+++ b/src/subscriptions-client/types/al-subscription.types.ts
@@ -250,21 +250,25 @@ export class AlEntitlementCollection
                 }
 
                 let productIds = groupExpression.split("|");
-                let entitlement = null;
+                let entitled = false;
                 for ( let p = 0; p < productIds.length; p++ ) {
                     let productId = productIds[p];
-                    let item = this.getProduct( productId );
-                    if ( item.active ) {
-                        entitlement = item;
-                        break;
+                    if ( productId === '*' ) {
+                        entitled = true;
+                    } else {
+                        let item = this.getProduct( productId );
+                        if ( item.active ) {
+                            entitled = true;
+                            break;
+                        }
                     }
                 }
 
                 if ( negatedGroup ) {
-                    entitlement = ! entitlement;
+                    entitled = ! entitled;
                 }
 
-                if ( ! entitlement ) {
+                if ( ! entitled ) {
                     result = false;
                     break;  //  no need to process further if we know this expression evaluates to false
                 }

--- a/test/subscriptions-client/entitlements.spec.ts
+++ b/test/subscriptions-client/entitlements.spec.ts
@@ -68,5 +68,12 @@ describe( 'AlEntitlementCollection', () => {
 
             expect( entitlements.evaluateExpression( "demeter|apollo&!zeus" ) ).to.equal( true );               //  because even though demeter isn't active, apollo but NOT zeus evaluates to true
         } );
+
+        it( 'SHOULD always treat the wildcard entitlement "*" as enabled', () => {
+            expect( entitlements.evaluateExpression( "*" ) ).to.equal( true );                                  //  essentially, "anything"
+            expect( entitlements.evaluateExpression( "!*" ) ).to.equal( false );                                //  essentially, "nothing"
+            expect( entitlements.evaluateExpression( "*&!*" ) ).to.equal( false );                              //  essentially, "anything" and "nothing", which is logically ridiculous
+                                                                                                                //      ...like myself...  and thus evaluates to false.
+        } );
     } );
 } );


### PR DESCRIPTION
Added support for the wildcard entitlement '*', which always evaluates
to `true`.  This construct is used heavily by protected views in various
apps.