### PR TITLE
ENG-0000: fix magma production acting node resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.184",
+  "version": "1.0.185",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/navigation/al-locator.types.ts
+++ b/src/common/navigation/al-locator.types.ts
@@ -95,14 +95,7 @@ export class AlLocation
                 environment: 'production',
                 residency: 'US',
                 uri: `${locTypeId===AlLocation.MagmaUI ? `https://console.alertlogic.com` : `https://console.${appCode}.alertlogic.com`}`,
-                keyword: appCode,
-            },
-            {
-                locTypeId: locTypeId,
-                environment: 'production',
-                residency: 'EMEA',
-                uri: `${locTypeId===AlLocation.MagmaUI ? 'https://console.alertlogic.com' : `https://console.${appCode}.alertlogic.co.uk`}`,
-                keyword: appCode,
+                keyword: `${locTypeId===AlLocation.MagmaUI ? 'console.alertlogic.com': appCode}`
             },
             {
                 locTypeId: locTypeId,
@@ -137,6 +130,16 @@ export class AlLocation
                 keyword: 'localhost',
             }
         ];
+        // Because we only deploy to one stack in prod for Magma now, only add the EMEA based prod nodes for all other non magma UI apps...
+        if(locTypeId!==AlLocation.MagmaUI){
+            nodes.push({
+                locTypeId: locTypeId,
+                environment: 'production',
+                residency: 'EMEA',
+                uri: `https://console.${appCode}.alertlogic.co.uk`,
+                keyword: appCode,
+            });
+        }
         if ( magmaRedirectPath ) {
             nodes.forEach( node => node.magmaRedirectPath = magmaRedirectPath );
         }

--- a/test/common/al-locator.spec.ts
+++ b/test/common/al-locator.spec.ts
@@ -182,6 +182,15 @@ describe( 'AlLocatorMatrix', () => {
 
         } );
 
+        it("should infer correct acting node for a magma production URL", () => {
+
+            locator.setActingUri( 'https://console.alertlogic.com/#/exposures/open/2' );
+            let actor = locator.getActingNode();
+            expect( actor.locTypeId ).to.equal( "cd21:magma" );
+            expect( actor.environment ).to.equal( "production" );
+            expect( actor.residency ).to.equal( "US" );
+        } );
+
         it("should infer correct context/sibling nodes for integration aliases", () => {
             //  Context inferred from PR demo bucket alias
             locator.setActingUri( 'https://overview-pr-199.ui-dev.product.dev.alertlogic.com/#/remediations-scan-status/2' );


### PR DESCRIPTION
Uncovered an issue where the actingNode resolution for console.alertlogic.com was alway returning null.

This was down to how we try to find matching `keyword` values in the URI, and the default `magma` keyword value is of course not present in the prod URL, so this introduces a special value for magma production