### PR TITLE
ENG-0000 - Removed Search from list of fully magmatized applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.185",
+  "version": "1.0.186",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/navigation/al-location.dictionary.ts
+++ b/src/common/navigation/al-location.dictionary.ts
@@ -174,7 +174,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
     ...AlLocation.uiNode(AlLocation.IntelligenceUI, 'intelligence', 4211),
     ...AlLocation.uiNode(AlLocation.ConfigurationUI, 'configuration', 4210),
     ...AlLocation.uiNode(AlLocation.RemediationsUI, 'remediations', 4212),
-    ...AlLocation.uiNode(AlLocation.SearchUI, 'search', 4220, '/#/search'),
+    ...AlLocation.uiNode(AlLocation.SearchUI, 'search', 4220 ),
     ...AlLocation.uiNode(AlLocation.EndpointsUI, 'endpoints', 8004),
     ...AlLocation.uiNode(AlLocation.DashboardsUI, 'dashboards', 7001, '/#/dashboards'),
     ...AlLocation.uiNode(AlLocation.HealthUI, 'health', 8003),


### PR DESCRIPTION
This will prevent automatic redirection by the AlIdentityResolutionGuard
service in @al/ng-navigation-components.