### PR TITLE
ENG-40660 - Support Transitional Navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.188",
+  "version": "1.0.189",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/errors/al-error.types.ts
+++ b/src/common/errors/al-error.types.ts
@@ -24,11 +24,13 @@ export class AlBaseError extends Error
      * this error.
      */
     public origin?:any;
+    public details?:any;
 
-    constructor( message?:string, derivedFrom?:any ) {
+    constructor( message?:string, derivedFrom?:any, details?:any ) {
         const trueProto = new.target.prototype;
         super(message);
         this.origin = derivedFrom;
+        this.details = details;
 
         this.__proto__ = trueProto;
     }
@@ -243,9 +245,9 @@ export class AlNotFoundError extends AlBaseError
  * @param inner - the underly error
  */
 export class AlWrappedError extends AlBaseError {
-    constructor( message:string, inner:any ) {
+    constructor( message:string, inner:any, details?:any ) {
         /* istanbul ignore next */
-        super( message, inner );
+        super( message, inner, details );
     }
 
     public getInnerError():any {

--- a/src/common/navigation/al-navigation.types.ts
+++ b/src/common/navigation/al-navigation.types.ts
@@ -50,6 +50,11 @@ export interface AlExperienceMapping
     trigger:AlRouteCondition|AlRouteCondition[]|boolean;
 
     /**
+     * If present and true, indicates the user can opt in or out of this experience, and their opt-in status should be "sticky."
+     */
+    optional?:boolean;
+
+    /**
      * If provided, defines the zero state to provide when an experience isn't available.
      */
     unavailable?: {

--- a/src/common/utility/al-trigger.types.ts
+++ b/src/common/utility/al-trigger.types.ts
@@ -76,7 +76,7 @@ export class AlTriggeredEvent<ResponseType=any>
  *
  * Callback type for triggered events.
  */
-export declare type AlTriggeredEventCallback<EventType> = {(event:EventType):void|boolean};
+export declare type AlTriggeredEventCallback<EventType> = {(event:EventType):void|boolean|Promise<void>};
 
 /**
  * @public


### PR DESCRIPTION
Adds support for conditionally enabled routes within a route hierarchy.
Routes that are disabled cannot be activated or made visible, and their
children are ignored.