### PR TITLE
ENG-0000 - Event for API Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.189",
+  "version": "1.0.190",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -54,7 +54,7 @@ import {
     AlInterceptionRule,
     AlInterceptionRules,
 } from './types';
-import { AlClientBeforeRequestEvent } from './events';
+import { AlClientBeforeRequestEvent, AlClientAPIErrorEvent } from './events';
 import { AIMSSessionDescriptor } from '../aims-client/types';
 import { AlRuntimeConfiguration, ConfigOption } from '../configuration';
 import { commonTypeSchematics } from './common.schematics';
@@ -975,6 +975,7 @@ export class AlApiClient implements AlValidationSchemaProvider
       data: errorResponse.data
     };
     this.log( `APIClient Failed Request Snapshot: ${JSON.stringify( snapshot, null, 4 )}` );
+    this.events.trigger( new AlClientAPIErrorEvent( errorResponse.config, errorResponse ) );
     return Promise.reject( errorResponse );
   }
 

--- a/src/client/events/index.ts
+++ b/src/client/events/index.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestConfig } from 'axios';
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import {
     AlTrigger,
     AlTriggeredEvent,
@@ -9,6 +9,14 @@ import { APIRequestParams } from '../types';
 export class AlClientBeforeRequestEvent extends AlTriggeredEvent<void>
 {
     constructor( public request:APIRequestParams ) {
+        super();
+    }
+}
+
+@AlTrigger( 'AlClientAPIError' )
+export class AlClientAPIErrorEvent extends AlTriggeredEvent<void>
+{
+    constructor( public request:APIRequestParams, public errorResponse:AxiosResponse ) {
         super();
     }
 }


### PR DESCRIPTION
`AlDefaultClient` now emits an event to its notification stream in the
case of API errors.