### PR TITLE
VTT-4934 btoa issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -584,12 +584,9 @@ export class AlApiClient implements AlValidationSchemaProvider
   }
 
   /**
-   * Converts a string input to its base64 encoded equivalent.  Uses browser-provided btoa if available, or 3rd party btoa module as a fallback.
+   * Converts a string input to its base64 encoded equivalent.
    */
   public base64Encode( data:string ):string {
-    if ( this.isBrowserBased() && window.btoa ) {
-        return btoa( data );
-    }
     let utf8Data = unescape( encodeURIComponent( data ) );        //  forces conversion to utf8 from utf16, because...  not sure why
     let bytes = [];
     for ( let i = 0; i < utf8Data.length; i++ ) {


### PR DESCRIPTION
The code for encrypting the username and password to base64 was generating invalid `Basic authorization` tokens when the £ character was used in passwords. 

The string should have been put through `unescape(encodeURIComponent(data))` first but it wasn't. When used in a browser the code used `btoa` directly. The non-browser code does use `unescape(encodeURIComponent(data))` and correctly generates the `Basic authorization` token.

Will therefore just remove the usage of btoa and use the base64js code instead. This code would be called outside of a browser environment.