### PR TITLE
ENG-48510 - dd support for single selection per category in the al-cardstack component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ dist
 .pnp.*
 
 .idea
+
+#history
+.history

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.196",
+  "version": "1.0.197",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -8,15 +8,13 @@ stages:
             - pull_request
             - pull_request:
                 trigger_phrase: test it
-        image: node:13
+        image: public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:4.0
         compute_size: small
         commands:
             - npm install
-            - apt-get install libdrm2 libgbm1
-            - echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
-            - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-            - apt-get update && apt-get -y install google-chrome-stable jq
-            - export CHROME_BIN='/usr/bin/google-chrome'
+            - curl https://intoli.com/install-google-chrome.sh | bash
+            - mv /usr/bin/google-chrome-stable /usr/bin/google-chrome
+            - google-chrome --version && which google-chrome
             - npm run test
             - npm run lint
             - npm run build
@@ -61,13 +59,12 @@ stages:
         name: Master Push - Publish
         when:
             - push: ['master']
-        image: node:13
+        image: public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:4.0
         compute_size: small
         commands:
-            - echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
-            - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-            - apt-get update && apt-get -y install google-chrome-stable
-            - export CHROME_BIN='/usr/bin/google-chrome'
+            - curl https://intoli.com/install-google-chrome.sh | bash
+            - mv /usr/bin/google-chrome-stable /usr/bin/google-chrome
+            - google-chrome --version && which google-chrome
             - |
               set -ex
 

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -12,6 +12,7 @@ stages:
         compute_size: small
         commands:
             - npm install
+            - apt-get install libdrm2 libgbm1
             - echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
             - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
             - apt-get update && apt-get -y install google-chrome-stable jq

--- a/src/common/cardstack/al-cardstack-view.ts
+++ b/src/common/cardstack/al-cardstack-view.ts
@@ -724,10 +724,10 @@ export abstract class AlCardstackView< EntityType=any,
             if ( existing.values.includes( vDescriptor ) ) {
                 return;     //  no change
             }
-            if(resetActiveFilters){
+            if ( resetActiveFilters ) {
                 existing.values = [];
                 pDescriptor.values.forEach(value => {
-                    if(vDescriptor.value !== value.value){
+                    if ( vDescriptor.value !== value.value ) {
                         value.activeFilter = false;
                     }
                 });

--- a/src/common/cardstack/al-cardstack-view.ts
+++ b/src/common/cardstack/al-cardstack-view.ts
@@ -299,10 +299,10 @@ export abstract class AlCardstackView< EntityType=any,
     /**
      *  Applies a filter to the current view, optionally specifying a custom filter callback.
      */
-    public applyFilterBy( vDescriptor:AlCardstackValueDescriptor,
+    public applyFilterBy( vDescriptor:AlCardstackValueDescriptor, resetActiveFilters: boolean = false,
                           callback?:{(entity:EntityType,properties:PropertyType,filter:AlCardstackActiveFilter<EntityType,PropertyType>):boolean} ) {
 
-        this.updateActiveFilters(vDescriptor, callback);
+        this.updateActiveFilters(vDescriptor, resetActiveFilters, callback);
         const pDescriptor = this.getProperty( vDescriptor.property );
         if ( pDescriptor.remote ) {
             this.start();       //  restart view
@@ -315,11 +315,11 @@ export abstract class AlCardstackView< EntityType=any,
     /**
      *  Applies multiple filter to the current view, optionally specifying a custom filter callback.
      */
-    public applyMultipleFilterBy( vDescriptors:AlCardstackValueDescriptor[],
+    public applyMultipleFilterBy( vDescriptors:AlCardstackValueDescriptor[], resetActiveFilters: boolean = false,
         callback?:{(entity:EntityType,properties:PropertyType,filter:AlCardstackActiveFilter<EntityType,PropertyType>):boolean} ) {
 
             vDescriptors.forEach(vDescriptor => {
-                this.updateActiveFilters(vDescriptor, callback);
+                this.updateActiveFilters(vDescriptor, resetActiveFilters, callback);
             });
     }
 
@@ -708,13 +708,29 @@ export abstract class AlCardstackView< EntityType=any,
         return this.activeFilters.filter( filter => filter.property.remote );
     }
 
-    protected updateActiveFilters(vDescriptor:AlCardstackValueDescriptor,
+    /**
+     * Updates the list of active filters based on the provided value descriptor.
+     *
+     * @param {AlCardstackValueDescriptor} vDescriptor - The value descriptor to apply as a filter.
+     * @param {boolean} [resetActiveFilters=false] - If true, clears all filters in the same category as the one being applied, leaving only the new filter active.
+     * @param {function} [callback] - An optional callback function to be called when the filter is applied.
+     * @returns {void}
+     */
+    protected updateActiveFilters(vDescriptor:AlCardstackValueDescriptor, resetActiveFilters: boolean = false,
                                   callback?:{(entity:EntityType,properties:PropertyType,filter:AlCardstackActiveFilter<EntityType,PropertyType>):boolean}) {
         const pDescriptor = this.getProperty( vDescriptor.property );
         const existing = this.activeFilters.find( filter => filter.property === pDescriptor );
         if ( existing ) {
             if ( existing.values.includes( vDescriptor ) ) {
                 return;     //  no change
+            }
+            if(resetActiveFilters){
+                existing.values = [];
+                pDescriptor.values.forEach(value => {
+                    if(vDescriptor.value !== value.value){
+                        value.activeFilter = false;
+                    }
+                });
             }
             existing.values.push( vDescriptor );
             existing.rawValues = existing.values.map( vDescr => vDescr.value );

--- a/test/common/al-cardstack.spec.ts
+++ b/test/common/al-cardstack.spec.ts
@@ -359,7 +359,7 @@ describe( 'AlCardstackView', () => {
         it( 'should show/hide items based on a custom filter', () => {
             let firstCard = stack.cards[0];
             let color = stack.getValue( "color", firstCard.properties.color );
-            stack.applyFilterBy( color, ( e, p, f ) => false );
+            stack.applyFilterBy( color, false, ( e, p, f ) => false );
             for ( let i = 0; i < stack.cards.length; i++ ) {
                 let card = stack.cards[i];
                 expect( card.visible ).to.equal( false );


### PR DESCRIPTION
# Report Download options

## User Story
[ENG-48510](https://alertlogic.atlassian.net/browse/ENG-48510)

## Description
This pull request adds a new optional parameter called "resetActiveFilters" to the "updateActiveFilters" function in order to enable resetting active filters when applying a new one.

When "resetActiveFilters" is set to true, the function will clear all filters selected in the same category as the one being applied, leaving only the new filter active. This behavior ensures that only one filter per category is applied at a time.

The implementation includes updating the active filter values and setting the corresponding flags for the affected property and value descriptors.

This feature could be useful in scenarios where users want to refine their search results by applying multiple filters, but only one per category.