### PR TITLE
ENG-48511 - Add setDefaultFiltersByParams function to allow setting active filters based on query parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.197",
+  "version": "1.0.198",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/cardstack/al-cardstack-view.ts
+++ b/src/common/cardstack/al-cardstack-view.ts
@@ -424,6 +424,37 @@ export abstract class AlCardstackView< EntityType=any,
     public decoratePropertyValue?( entity:EntityType, property:AlCardstackPropertyDescriptor, value:AlCardstackValueDescriptor );
 
     /**
+     * Sets the active filters based on the specified query parameters.
+     * This function is useful when using deep links.
+     *
+     * @param {Object} params - The query parameters object.
+     * @throws {Error} If `characteristics` is not configured, an error will be thrown.
+     * @returns {void}
+     */
+    public setDefaultFiltersByParams(params: {[key:string]: string}) {
+        if(!this.characteristics){
+            throw new Error("characteristics must be configured to activate filters via query parameters.");
+        }
+        const filterableBy = this.characteristics.filterableBy;
+        if (filterableBy.length > 0) {
+            for (let i = 0; i < filterableBy.length; i++) {
+                const filterProperty = filterableBy[i] as string;
+                if (filterProperty in params && params[filterProperty] && filterProperty in this.characteristics.definitions) {
+                    const values = params[filterProperty].split(',');
+                    const activeFilters: AlCardstackValueDescriptor[] = [];
+                    values.forEach(value => {
+                        const filter = this.characteristics.definitions[filterProperty].values.find(characteristicValue => characteristicValue.value === value);
+                        if (filter) {
+                            activeFilters.push(filter);
+                        }
+                    });
+                    this.applyMultipleFilterBy(activeFilters);
+                }
+            }
+        }
+    }
+
+    /**
      * Protected Internal Methods
      */
 
@@ -732,6 +763,7 @@ export abstract class AlCardstackView< EntityType=any,
                     }
                 });
             }
+            // debugger;
             existing.values.push( vDescriptor );
             existing.rawValues = existing.values.map( vDescr => vDescr.value );
         } else {

--- a/src/common/cardstack/al-cardstack-view.ts
+++ b/src/common/cardstack/al-cardstack-view.ts
@@ -763,7 +763,6 @@ export abstract class AlCardstackView< EntityType=any,
                     }
                 });
             }
-            // debugger;
             existing.values.push( vDescriptor );
             existing.rawValues = existing.values.map( vDescr => vDescr.value );
         } else {


### PR DESCRIPTION
# Report Download options

## User Story
[ENG-48511](https://alertlogic.atlassian.net/browse/ENG-48511)

## Description
This pull request adds a new function called `setDefaultFiltersByParams` to allow setting active filters based on query parameters. The function takes a dictionary of query parameters and compares them to the filterable characteristics defined in the cardstack. If there is a match, it applies the active filters to the cardstack.

This function is useful for when users share deeplinks that contain filter parameters, as it will automatically apply those filters when the page is loaded.