### PR TITLE
ENG-0000 - Fixed token info endpoint

### DIFF
--- a/lib/nucleus/src/session/al-authentication.utility.ts
+++ b/lib/nucleus/src/session/al-authentication.utility.ts
@@ -248,7 +248,8 @@ export class AlAuthenticationUtility extends AlBaseAPIClient {
         return this.get( {
             endpoint: { 
                 configuration: "aims",
-                path: '/token_info' 
+                path: '/token_info',
+                aimsAuthHeader: false
             },
             headers: { 'X-AIMS-Auth-Token': accessToken },
         } );

--- a/lib/nucleus/src/session/al-session.ts
+++ b/lib/nucleus/src/session/al-session.ts
@@ -126,7 +126,6 @@ export class AlSessionInstance
     public async setAuthentication( proposal: AIMSSessionDescriptor ):Promise<AlActingAccountResolvedEvent> {
       try {
         this.startDetection();
-        let authenticationSchemaId = "https://alertlogic.com/schematics/aims#definitions/authentication";
 
         if ( proposal.authentication.token_expiration <= this.getCurrentTimestamp()) {
           throw new AlError( "AIMS authentication response contains unexpected expiration timestamp in the past", undefined, proposal.authentication );
@@ -153,7 +152,6 @@ export class AlSessionInstance
         this.storage.set("session", this.session );
         return result;
       } catch( e ) {
-        console.error( e );
         AlError.log( e, `AlSession.setAuthentication() failed` );
         this.deactivateSession();
         throw e;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./bundles/al-core-nucleus.es5.js",
   "types": "./types/al-core-nucleus.d.ts",


### PR DESCRIPTION
The current auth token was overwriting the one being inquired about, causing confusion when changing working accounts in e2e test suites.