### PR TITLE
ENG-0000 - Removed const enums

### DIFF
--- a/lib/configuration/src/exclusions/types/index.ts
+++ b/lib/configuration/src/exclusions/types/index.ts
@@ -302,32 +302,32 @@ export class AllExclusionsToSave {
     changes: boolean;
 }
 
-export const enum BlackoutsResolution {
+export enum BlackoutsResolution {
     weekly = 'weekly',
     monthly = 'monthly',
     exact_date = 'exact_date',
     permanent = 'permanent'
 }
 
-export const enum AssetType {
+export enum AssetType {
     cidr = 'cidr',
     asset = 'asset',
     tag = 'tag'
 }
 
-export const enum DetailsFeature {
+export enum DetailsFeature {
     scan = 'scan',
     ids = 'ids'
 }
 
-export const enum ScanType {
+export enum ScanType {
     vulnerability = 'vulnerability',
     pci = 'pci',
     discovery = 'discovery',
     external = 'external'
 }
 
-export const enum Protocols {
+export enum Protocols {
     tcp = 'tcp',
     udp = 'udp',
     icmp = 'icmp',

--- a/lib/reporting/src/responder/types/playbookTypes.ts
+++ b/lib/reporting/src/responder/types/playbookTypes.ts
@@ -826,7 +826,7 @@ export interface AlManageBlockStatus {
     intent: AlBlockIntent;
 }
 
-export const enum AlBlockIntent {
+export enum AlBlockIntent {
     BlockSoft = "block_soft",
     UnblockSoft = "unblock_soft",
     BlockForce = "block_force",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./bundles/al-core-nucleus.es5.js",
   "types": "./types/al-core-nucleus.d.ts",


### PR DESCRIPTION
Const enums are evaluated entirely at compile time, which makes sense for an application (where the values are implicitly inlined) but NOT for a library (in which case the declaration suggests the enum exists, but it is not emitted into the compiled javascript).