### PR TITLE
ENG-0000 - Fix 'withCredentials' property

### DIFF
--- a/lib/nucleus/src/client/al-base-api-client.ts
+++ b/lib/nucleus/src/client/al-base-api-client.ts
@@ -252,6 +252,10 @@ export class AlBaseAPIClient extends AlAbstractClient {
             if ( typeof( descriptor.credentialed ) === 'boolean' ) {
                 request.credentialed = descriptor.credentialed;
             }
+            if ( typeof( ( descriptor as any ).withCredentials ) === 'boolean' ) {  
+                /* honor 'withCredentials' when provided instead of 'credentialed' */
+                request.credentialed = ( descriptor as any ).withCredentials;
+            }
             if ( descriptor.debug ) {
                 request.debug = true;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./bundles/al-core-nucleus.es5.js",
   "types": "./types/al-core-nucleus.d.ts",


### PR DESCRIPTION
Older requests used this property instead of 'credentialed', and the base API client needs to respect both.