### PR TITLE
ENG-0000 - Remove EMEA domain variants from UI Nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.0.209",
+  "version": "1.1.0-beta.1",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/navigation/al-locator.types.ts
+++ b/src/common/navigation/al-locator.types.ts
@@ -113,7 +113,7 @@ export class AlLocation
                 locTypeId: locTypeId,
                 environment: 'production-staging',
                 residency: 'EMEA',
-                uri: locTypeId === AlLocation.MagmaUI ? `https://${appCode}-production-staging-us.ui-dev.product.dev.alertlogic.com` : `https://${appCode}-production-staging-uk.ui-dev.product.dev.alertlogic.com`,
+                uri: `https://${appCode}-production-staging-us.ui-dev.product.dev.alertlogic.com`,
                 keyword: appCode,
             },
             {


### PR DESCRIPTION
This should hypothetically prevent the UI from navigating away from .com domains and into .co.uk domains, while continuing to allow datacenter selections to target any datacenter.