### PR TITLE
ENG-0000 - Revised Node Resolution Again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/navigation/al-locator.types.ts
+++ b/src/common/navigation/al-locator.types.ts
@@ -94,29 +94,37 @@ export class AlLocation
      * Generates location type definitions for residency-specific prod, integration, and dev versions of a UI
      */
     public static uiNode( locTypeId:string, appCode:string, devPort:number, magmaRedirectPath?: string ):AlLocationDescriptor[] {
-        let nodes:AlLocationDescriptor[] = [
-            {
+        let nodes:AlLocationDescriptor[] = [];
+
+        if ( locTypeId === AlLocation.MagmaUI ) {
+            nodes.push( {
                 locTypeId: locTypeId,
                 environment: 'production',
                 residency: 'US',
-                uri: `${locTypeId===AlLocation.MagmaUI ? `https://console.alertlogic.com` : `https://console.${appCode}.alertlogic.com`}`,
+                uri: `https://console.alertlogic.com`,
                 keyword: `${locTypeId===AlLocation.MagmaUI ? 'console.alertlogic.com': appCode}`
-            },
-            {
+            } );
+        } else {
+            nodes.push( {
                 locTypeId: locTypeId,
-                environment: 'production-staging',
+                environment: 'production',
                 residency: 'US',
-                uri: `https://${appCode}-production-staging-us.ui-dev.product.dev.alertlogic.com`,
-                keyword: appCode,
-            },
-            {
-                locTypeId: locTypeId,
-                environment: 'production-staging',
-                residency: 'EMEA',
-                uri: `https://${appCode}-production-staging-us.ui-dev.product.dev.alertlogic.com`,
-                keyword: appCode,
-            },
-            {
+                uri: `https://console.${appCode}.alertlogic.com`,
+                aliases: [ `https://console.${appCode}.alertlogic.co.uk` ],
+                keyword: `${locTypeId===AlLocation.MagmaUI ? 'console.alertlogic.com': appCode}`
+            } );
+        }
+
+        nodes.push( {
+            locTypeId: locTypeId,
+            environment: 'production-staging',
+            residency: 'US',
+            uri: `https://${appCode}-production-staging-us.ui-dev.product.dev.alertlogic.com`,
+            keyword: appCode,
+            aliases: [ `https://${appCode}-production-staging-uk.ui-dev.product.dev.alertlogic.com` ]
+        } );
+
+        nodes.push( {
                 locTypeId: locTypeId,
                 environment: 'integration',
                 uri: `https://console.${appCode}.product.dev.alertlogic.com`,
@@ -134,17 +142,8 @@ export class AlLocation
                 uri: `http://localhost:${devPort}`,
                 keyword: 'localhost',
             }
-        ];
-        // Because we only deploy to one stack in prod for Magma now, only add the EMEA based prod nodes for all other non magma UI apps...
-        if(locTypeId!==AlLocation.MagmaUI){
-            nodes.push({
-                locTypeId: locTypeId,
-                environment: 'production',
-                residency: 'EMEA',
-                uri: `https://console.${appCode}.alertlogic.com`,
-                keyword: appCode,
-            });
-        }
+        );
+
         if ( magmaRedirectPath ) {
             nodes.forEach( node => node.magmaRedirectPath = magmaRedirectPath );
         }


### PR DESCRIPTION
Moves UK instances of O3 applications (and magma) into node aliases, rather than being separate nodes.  This has the following ramifications:

    - UK urls can still be recognized and mapped to the correct
      environment
    - UK urls will resolve to the US equivalent nodes when looked up by
      domain
    - While the locator matrix will take residency into account for API and
      defender nodes, it will never generate URLs linking to .co.uk for
      UI-related resources