### PR TITLE
VTT-5827 - Updated Gestalt Session Detection Default Origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/configuration/al-runtime-configuration.ts
+++ b/src/configuration/al-runtime-configuration.ts
@@ -86,7 +86,7 @@ export class AlRuntimeConfiguration {
 
     protected static defaultOptions:{[optionKey:string]:string|number|boolean|unknown} = {
         'session_via_gestalt': false,
-        'session_gestalt_domain': 'cd17:accounts',
+        'session_gestalt_domain': 'cd21:magma',
         'session_metadata': true,
         'session_consolidated_resolver': false,
         'disable_endpoints_resolution': false,

--- a/src/session/utilities/al-session-detector.ts
+++ b/src/session/utilities/al-session-detector.ts
@@ -192,7 +192,7 @@ export class AlSessionDetector
         if ( environment === 'development' ) {
             environment = 'integration';
         }
-        let sessionStatusURL = AlLocatorService.resolveURL( AlLocation.AccountsUI, `/session/v1/status`, { residency, environment } );
+        let sessionStatusURL = AlLocatorService.resolveURL( AlLocation.MagmaUI, `/session/v1/status`, { residency, environment } );
         let sessionStatus = await AlDefaultClient.get( {
             url: sessionStatusURL,
             withCredentials: true


### PR DESCRIPTION
Updated `AlRuntimeConfiguration` so that the default domain for interacting with gestalt's session proxy API is `AlLocation.MagmaUI` instead of `AlLocation.AccountsUI`.