### PR TITLE
ENG-51868 - Add Support for new TOS Workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/aims-client/aims-client.ts
+++ b/src/aims-client/aims-client.ts
@@ -813,7 +813,40 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
           path: '/organization'
       };
       return await this.client.get( requestDescriptor ) as AIMSOrganization;
-    }
+  }
+
+  /**
+   * Retrieves licensing status information for a given accountId.
+   */
+  async getLicenseAcceptanceStatus( accountId:string ):Promise< {
+                                                                    status: string,
+                                                                    tos_url?: string,
+                                                                    tos_deferral_period_end?: number,
+                                                                } > {
+      return await this.client.get( {
+          service_stack: AlLocation.InsightAPI,
+          service_name: this.serviceName,
+          version: 1,
+          account_id: accountId,
+          path: '/tos_status'
+      } );
+  }
+
+  /**
+   * Updates license acceptance for a given accountId.
+   */
+  async setLicenseAcceptance( accountId:string, accepted:boolean ) {
+      return await this.client.post( {
+          service_stack: AlLocation.InsightAPI,
+          service_name: this.serviceName,
+          version: 1,
+          account_id: accountId,
+          path: '/tos_status',
+          data: {
+              accept_tos: accepted
+          }
+      } );
+  }
 
   /**
    * This endpoint render's an accounts related accounts topologically by adding a :relationship field to the account object,

--- a/src/session/utilities/al-authentication.utility.ts
+++ b/src/session/utilities/al-authentication.utility.ts
@@ -1,7 +1,7 @@
 import { AlDefaultClient } from '../../client';
 import { AlSession } from '../al-session';
 import { AlLocatorService, AlLocation } from '../../common/navigation';
-import { AIMSSessionDescriptor, FortraSession, AIMSAuthentication } from '../../aims-client/types';
+import { AIMSClient, AIMSSessionDescriptor, FortraSession, AIMSAuthentication } from '../../aims-client/index';
 import { AlRuntimeConfiguration, ConfigOption } from '../../configuration';
 import { AlConduitClient } from './al-conduit-client';
 import { getJsonPath } from '../../common/utility';
@@ -186,6 +186,13 @@ export class AlAuthenticationUtility {
             }
         }
         return this.state.result;
+    }
+
+    /**
+     * Updates the user's TOS status when a session is already established.
+     */
+    public async updateTermsOfServiceAcceptance( accountId:string, acceptTOS:boolean = true ):Promise<void> {
+        return await AIMSClient.setLicenseAcceptance( accountId, acceptTOS );
     }
 
     /**


### PR DESCRIPTION
Exposes two new methods on `AIMSClient` to get and set license status for an authenticated account, as well as a convenience method on `AlAuthenticationUtility`.