### PR TITLE
ENG-52677 - Adding a new Al Trigger Event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/events/events.ts
+++ b/src/session/events/events.ts
@@ -106,3 +106,14 @@ export class AlExternalTrackableEvent extends AlTriggeredEvent<void>
         super();
     }
 }
+
+/**
+ * AlFortraTokenChangedEvent is emitted by an AlSessionInstance each time the Fortra token is refreshed.
+ */
+@AlTrigger( 'AlFortraTokenChanged' )
+export class AlFortraTokenChangedEvent extends AlTriggeredEvent<void>
+{
+    constructor( public token:string ) {
+        super();
+    }
+}


### PR DESCRIPTION
The AlFortraTokenChangedEvent class is an Al trigger evennt which is emitted by an AlSessionInstance whenever the Fortra token is refreshed.