### PR TITLE
ENG-0000 - Conduit Base URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -745,7 +745,6 @@ export class AlApiClient implements AlValidationSchemaProvider
         console.error(`resolveDefaultEndpoints() => endpointCache: `, this.endpointCache);
       }
     }
-   
   }
 
   public async resolveResidencyAwareEndpoints( accountId:string, serviceList:string[] ) {

--- a/src/configuration/al-runtime-configuration.ts
+++ b/src/configuration/al-runtime-configuration.ts
@@ -45,8 +45,8 @@ export interface AlParamPreservationRule {
  *   - ConfigOption.NavigationViaConduit - if enabled, AlNavigationService will attempt to retrieve navigation metadata from a conduit request
  *      (which queries console.account for a static asset).  Defaults to 'false.'
  *
- *   - ConfigOption.ExternalConduitFrame - if set, the conduit client will *not* create the conduit iframe and add it to the document dynamically,
- *      trusting the parent application to have already done so.
+ *   - ConfigOption.ExternalConduitFrame - if set, the conduit client will treat the value as the id of an externally created iframe created by the
+ *      application host or parent.  Otherwise, the conduit iframe will be created dynamically.
  *
  *   - ConfigOption.NavigationViaGestalt - if enabled, AlNavigationService will attempt to retrieve navigation metadata from gestalt
  *      (via AlExternalContentManagerService).  Defaults to 'true.'
@@ -73,6 +73,7 @@ export enum ConfigOption {
     LocalManagedContent         = "xcontent_local",
     ManagedContentAssetPath     = "xcontent_asset_path",
     NavigationViaConduit        = "navigation_use_conduit",
+    NavigationConduitLocation   = "navigation_conduit_location",
     ExternalConduitFrame        = "navigation_external_conduit",
     NavigationViaGestalt        = "navigation_use_gestalt",
     NavigationAssetPath         = "navigation_asset_path",

--- a/src/session/utilities/al-conduit-client.ts
+++ b/src/session/utilities/al-conduit-client.ts
@@ -32,7 +32,6 @@ export class AlConduitClient
     protected static requestIndex = 0;
 
     public start( targetDocument?:Document ) {
-        console.log("AlConduitClient is starting" );
         if ( ! targetDocument ) {
             if ( typeof( document ) === 'undefined' ) {
                 AlErrorHandler.report( new Error( "AlConduitClient cannot start in headless mode." ) );
@@ -69,7 +68,8 @@ export class AlConduitClient
         if ( environment === 'development' ) {
             environment = 'integration';
         }
-        AlConduitClient.conduitUri = AlLocatorService.resolveURL( AlLocation.MagmaUI, '/conduit.html', { residency, environment } );
+        let locationId = AlRuntimeConfiguration.getOption<string>( ConfigOption.NavigationConduitLocation, AlLocation.AccountsUI );
+        AlConduitClient.conduitUri = AlLocatorService.resolveURL( locationId, '/conduit.html', { residency, environment } );
         const fragment = AlConduitClient.document.createDocumentFragment();
         const container = AlConduitClient.document.createElement( "div" );
         container.setAttribute("id", "conduitClient" );


### PR DESCRIPTION
Added a configuration option for which domain to use to interact with the conduit microapplication.  This defaults to console.account, but will allow us to roll forward to the magma version of conduit once it is available.

Also cleaned up Cris's trailing whitespace linting error :P