### PR TITLE
ENG-53328 - Feature Flagging for Menu Items and Banners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/aims-client/aims-client.ts
+++ b/src/aims-client/aims-client.ts
@@ -23,6 +23,7 @@ import {
     AIMSUser,
     AIMSUserDetails,
     AIMSEnrollURI,
+    AIMSLicenseAcceptanceStatus,
 } from './types';
 import { aimsTypeSchematics } from './aims.schematics';
 
@@ -818,11 +819,7 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
   /**
    * Retrieves licensing status information for a given accountId.
    */
-  async getLicenseAcceptanceStatus( accountId:string ):Promise< {
-                                                                    status: string,
-                                                                    tos_url?: string,
-                                                                    tos_deferral_period_end?: number,
-                                                                } > {
+  async getLicenseAcceptanceStatus( accountId:string ):Promise<AIMSLicenseAcceptanceStatus> {
       return await this.client.get( {
           service_stack: AlLocation.InsightAPI,
           service_name: this.serviceName,
@@ -887,6 +884,23 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
     }
     const first = addCurrentId ? [accountId] : [];
     return [...first, ...getIds(topology[relationship])];
+  }
+
+  /**
+   * Retrieves the Frontline PCI scan migration status for a given account.  This is a placeholder for future functionality.
+   */
+  async getFrontlineMigrationStatus( accountId:string ):Promise<any> {
+      return Promise.resolve( {
+          accountId,
+          status: 'pending'
+      } );
+  }
+
+  /**
+   * Triggers Frontline PCI scan migration for a given account.
+   */
+  async startFrontlineMigration( accountId:string ):Promise<boolean> {
+      return Promise.resolve( true );
   }
 
   /**

--- a/src/aims-client/types/types.ts
+++ b/src/aims-client/types/types.ts
@@ -126,3 +126,9 @@ export interface AIMSTopology extends AIMSAccount {
     managing?: AIMSTopology[];
     managed?: AIMSTopology[];
 }
+
+export interface AIMSLicenseAcceptanceStatus {
+    status: string;
+    tos_url?: string;
+    tos_deferral_period_end?: number;
+}

--- a/src/common/navigation/al-route.types.ts
+++ b/src/common/navigation/al-route.types.ts
@@ -111,11 +111,17 @@ export interface AlRouteCondition
     //  An array of account IDs that fulfill the condition
     accounts?:string[];
 
+    //  Account property/value arrays
+    accountProps?:{ name:string, values:any[] }[];
+
     //  An array of user IDs that fulfill the condition
     userIds?:string[];
 
     //  An array of primary account IDs that fulfill the condition
     primaryAccounts?:string[];
+
+    //  Primary account property/value arrays
+    primaryAccountProps?:{ name:string, values:any[] }[];
 
     //  An array of locations to match against (e.g., "defender-us-denver", "insight-us-virginia", etc), measured against the acting account.
     locations?:string[];
@@ -649,6 +655,7 @@ export class AlRoute {
         if ( condition.authentication
                 || condition.accounts || condition.primaryAccounts
                 || condition.entitlements || condition.primaryEntitlements
+                || condition.accountProps || condition.primaryAccountProps
                 || condition.environments
                 || condition.experiences ) {
             //  This condition refers to entitlement or other externally managed data -- ask the host to evaluate it.

--- a/src/session/events/events.ts
+++ b/src/session/events/events.ts
@@ -1,6 +1,7 @@
 import {
     AIMSAccount,
     AIMSUser,
+    AIMSLicenseAcceptanceStatus,
 } from "../../aims-client";
 import {
     AlTrigger,
@@ -56,7 +57,9 @@ export class AlActingAccountResolvedEvent extends AlTriggeredEvent<void>
 {
     constructor( public actingAccount:AIMSAccount,
                  public entitlements:AlEntitlementCollection,
-                 public primaryEntitlements:AlEntitlementCollection ) {
+                 public primaryEntitlements:AlEntitlementCollection,
+                 public licenseAcceptance?:AIMSLicenseAcceptanceStatus,
+                 public coreServiceError?:string ) {
         super();
     }
 }

--- a/src/session/types/types.ts
+++ b/src/session/types/types.ts
@@ -13,10 +13,3 @@ export interface AlConsolidatedAccountMetadata {
     effectiveEntitlements:AlEntitlementRecord[];
     endpointsData:any;
 }
-
-export interface AlSessionProfile {
-    entitlements?:string[];
-    primaryEntitlements?:string[];
-    globalExperience?:string;
-    experiences?:string[];
-}


### PR DESCRIPTION
Adds `accountProps` and `primaryAccountProps` to route conditions interface to allow menu items and experience mappings to toggle based on AIMS account properties.

Also, updated account resolution to eliminate the unused `profile` feature, remove the unused consolidated resolver mechanism, and to be more failure tolerant (using `Promise.allSettled()` and allowing selective failure).

ALSO, incorporated license status evaluation into account resolution.