### PR TITLE
ENG-0000 - Synchronize Refreshed Tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -345,7 +345,7 @@ export class AlSessionInstance
       if ( this.sessionData.fortraSession ) {
           this.sessionData.fortraSession.accessToken = token;
       }
-      this.storage.set("session", this.sessionData );
+      this.storage.set("session", this.sessionData ).synchronize();
     }
 
     /**


### PR DESCRIPTION
This is important in cases where unavailability of the SSO-check iframe may cause a redirect, which would cause updated tokens to be lost.