### PR TITLE
ENG-54318 - Logout Functionality Not Working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -158,6 +158,9 @@ export class AlSessionInstance
               }
               this.setTokenInfo( token, expirationTTL );
               console.log("Updated AIMS Token to expire in %s seconds from now", offset );
+          },
+          logging: ( enable:boolean ) => {
+              AlErrorHandler.verbose = enable;
           }
       } );
     }


### PR DESCRIPTION
Fixes conduit to only respond to messages from the target URL, which allows multiple conduit clients to coexist peacefully (and in turn, allows logout to complete purge of conduit session data).

Also allows logging to be enabled programmatically in the console.