### PR TITLE
ENG-0000 - Allow Explicit Authentication Header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/aims-client/aims-client.ts
+++ b/src/aims-client/aims-client.ts
@@ -33,6 +33,7 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
   private client:AlApiClient;
   private serviceName = 'aims';
   private serviceVersion:string = "v1";
+  /* tslint:disable:variable-name*/
   private _usersDict = {};
   public get usersDict() {
     return this._usersDict;
@@ -148,23 +149,23 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
      * @param {string[]} userIds - Array of user IDs to load details for.
      * @returns {Promise<void>} A promise that resolves once all user details are loaded.
      */
-    async loadUserNames(userIds: string[]): Promise<void> {
-      var promises: Promise<AIMSUser>[] = [];
+  async loadUserNames(userIds: string[]): Promise<void> {
+      let promises: Promise<AIMSUser>[] = [];
       userIds.forEach((id) => {
         if (!(id in this._usersDict)) {
           promises.push(AIMSClient.getUserDetailsByUserId(id));
         }
       });
-      var results = await Promise.allSettled(promises);
+      let results = await Promise.allSettled(promises);
       results.forEach((result, index) => {
-        var id = userIds[index];
+        let id = userIds[index];
         if (result.status === 'fulfilled') {
           this._usersDict[id] = result.value.name ?? '';
         } else if(result.status === 'rejected') {
           this._usersDict[id] = 'Unknown User';
         }
       });
-    }
+  }
 
   /**
    * Get user permissions

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -714,10 +714,12 @@ export class AlSessionInstance
                 ||
              ( this.authenticatedStacks.includes( event.request.service_stack ) && event.request.aimsAuthHeader !== false ) ) {
           event.request.headers = event.request.headers || {};
-          if ( this.sessionData?.fortraSession ) {
+          if ( ! ( 'X-AIMS-Auth-Token' in event.request.headers ) && ! ( 'Authorization' in event.request.headers ) ) {
+            if ( this.sessionData?.fortraSession ) {
               event.request.headers['Authorization'] = `Bearer ${this.sessionData.fortraSession.accessToken}`;
-          } else {
+            } else {
               event.request.headers['X-AIMS-Auth-Token'] = this.getToken();
+            }
           }
         }
       }


### PR DESCRIPTION
Suppresses the built-in logic for adding authentication headers if the requestor provides one of their own.

Also fixes recent changes to aims-client.ts to pass linting.