### PR TITLE
ENG-0000 - Restored Nullish Coalescer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.31",
+  "version": "1.2.32",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/aims-client/aims-client.ts
+++ b/src/aims-client/aims-client.ts
@@ -160,7 +160,7 @@ export class AIMSClientInstance implements AlValidationSchemaProvider {
       results.forEach((result, index) => {
         let id = userIds[index];
         if (result.status === 'fulfilled') {
-          this._usersDict[id] = result.value.name || '';
+          this._usersDict[id] = result.value.name ?? '';
         } else if(result.status === 'rejected') {
           this._usersDict[id] = 'Unknown User';
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "sourceMap"                       : true,
     "strict"                          : true,
     "strictNullChecks"                : false,
-    "target"                          : "ES2020",
+    "target"                          : "ES2018",
     "typeRoots"                       : [
       "node_modules/@types"
     ],


### PR DESCRIPTION
Because the real source of the problem was me: I changed the compilation target to ES2020, which allowed the nullish coalescer and optional chaining to be emitted without transpilation.