### PR TITLE
ENG-0000 - Core Routing/Navigation Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@al/core",
-  "version": "1.2.35",
+  "version": "1.2.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@al/core",
-      "version": "1.2.35",
+      "version": "1.2.37",
       "license": "MIT",
       "dependencies": {
         "auth0-js": "^9.16.2",
@@ -37,6 +37,7 @@
         "rollup-plugin-copy": "^3.3.0",
         "rollup-plugin-terser": "^5.3.0",
         "rollup-plugin-typescript2": "^0.27.0",
+        "safe-stringify": "^1.1.1",
         "sinon": "^9.0.2",
         "ts-loader": "^6.2.2",
         "tslint": "^5.12.1",
@@ -11062,6 +11063,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-stringify/-/safe-stringify-1.1.1.tgz",
+      "integrity": "sha512-YSzQLuwp06fuvJD1h6+vVNFYZoXmDs5UUNPUbTvQK7Ap+L0qD4Vp+sN434C+pdS3prVVlUfQdNeiEIgxox/kUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safer-buffer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.37",
+  "version": "1.2.38",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/common/navigation/al-location.dictionary.ts
+++ b/src/common/navigation/al-location.dictionary.ts
@@ -558,15 +558,17 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
     /**
      * Fortra Platform Base URL
      */
+    /*
     {
         locTypeId: AlLocation.FortraPlatform,
         uri: 'https://foundation.foundation-dev.cloudops.fortradev.com',
         environment: 'development',
     },
+    */
     {
         locTypeId: AlLocation.FortraPlatform,
         uri: 'https://foundation.foundation-stage.cloudops.fortradev.com',
-        environment: 'integration',
+        environment: 'integration|development',
     },
     {
         locTypeId: AlLocation.FortraPlatform,

--- a/src/session/utilities/al-conduit-client.ts
+++ b/src/session/utilities/al-conduit-client.ts
@@ -194,10 +194,6 @@ export class AlConduitClient
      */
     public getGlobalSetting(settingKey: string): Promise<any> {
         return this.request("conduit.getGlobalSetting", { setting_key: settingKey })
-            .then( rawResponse => {
-                console.log("Raw response from conduit.request: ", rawResponse );
-                return rawResponse;
-            } )
             .then( rawResponse => rawResponse ? rawResponse.setting : null );
     }
 


### PR DESCRIPTION
This change normalizes the `AlRoute*` family of classes in such a way that an application using @al/core can run properly in a subdirectory, regardless of whether or not a trailing slash is or isn't present.

Adjusts unit tests to validate this behavior, as well as the existing behavior when AlLocatorService's `remapLocationURI` method is called.

Removed some noisy, obsolete debug logging

Updated location dictionary so that development and integration both default to using Fortra's Staging environment (rather then the development one).