### PR TITLE
ENG-0000 - Hotfix for SSO Detection via Keycloak

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.39",
+  "version": "1.2.40",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/utilities/al-identity-providers.ts
+++ b/src/session/utilities/al-identity-providers.ts
@@ -67,7 +67,8 @@ export class AlIdentityProviders
                                new Promise<void>( async ( resolve, reject ) => {
                                     let cloakPhase = this.storage.get("cloakInitPhase", 0 );
                                     let onLoad:KeycloakOnLoad|undefined = cloakPhase === 0 ? "check-sso" : undefined;
-                                    let silentCheckSsoRedirectUri = cloakPhase === 0 ? `${window.location.origin}${window.location.pathname}/sso-check.html` : undefined;
+                                    const baseLocation = window.location.origin + ( window.location.pathname === '/' ? '' : window.location.pathname );     //  fix double slash but support apps in subdirectories
+                                    let silentCheckSsoRedirectUri = cloakPhase === 0 ? `${baseLocation}/sso-check.html` : undefined;
                                     this.storage.set("cloakInitPhase", cloakPhase + 1, 10 ).synchronize();
                                     if ( cloakPhase > 5 ) {
                                         this.allIsLost = true;


### PR DESCRIPTION
Fix a defect that was inadvertantly introduced by the addition of support for running the console in a subdirectory: the base path '/' caused the location of the sso-check mechanism to have a double slash, causing a 403 error from cloudfront/s3, in turn causing sessions to die immediately after they have been created.