### PR TITLE
ENG-56603 - Auth0 Workflow Preservation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.41",
+  "version": "1.2.42",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/utilities/al-identity-providers.ts
+++ b/src/session/utilities/al-identity-providers.ts
@@ -30,9 +30,24 @@ export class AlIdentityProviders
     constructor() {
     }
 
+    public static inAuth0Workflow( url:string ):boolean {
+        if ( ! url ) {
+            return false;
+        }
+        if ( ! /state=([a-zA-Z0-9\-_]+)/.test( url ) ) {    //  this parameter must always be present
+            return false;
+        }
+        if ( /iss=([^&]+)/.test( url ) ) {                  //  this parameter suggests we're in a keycloak redirection flow
+            return false;
+        }
+        return true;
+    }
+
     public async warmup() {
         try {
-            await this.getKeycloak();
+            if ( ! AlIdentityProviders.inAuth0Workflow(window?.location?.href) ) {
+                await this.getKeycloak();
+            }
         } catch( e ) {
             console.error( e );
         }


### PR DESCRIPTION
In order to support authentication via keycloak in environments without 3rd party cookies, it is essential to initialize the keycloak adapter BEFORE angular takes control of the application's URL.  However, this preemptive initialization also causes keycloak to override auth0 workflows because both are OIDC implementations that share a subset of query parameters.  This change attempts to differentiate between keycloak and auth0 workflows so that keycloak can still be initialized preemptively, but NOT when it is inappropriate.