### PR TITLE
ENG-56603 - Auth0 Support Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.45",
+  "version": "1.2.46",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Reinstated the old "magical rewrite" rules from console.account inside @al/core's `AlIdentityProviders` utility class.