### PR TITLE
ENG-0000 - Implicit Residency Awareness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.2.49",
+  "version": "1.2.50",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -871,14 +871,19 @@ export class AlApiClient implements AlValidationSchemaProvider
    */
   protected async prepare( requestParams:APIRequestParams ): Promise<string> {
     let result = await this.endpointsGuard.run<string>( async () => {
-      const environment         =   AlLocatorService.getCurrentEnvironment();
-      const accountId           =   requestParams.context_account_id || requestParams.account_id || this.defaultAccountId || "0";
-      const serviceEndpointId   =   requestParams.target_endpoint || requestParams.service_name;
-      const residencyAware      =   AlApiClient.resolveByResidencyServiceList.includes( serviceEndpointId );
-      let residency             =   requestParams.residency ?? "default";
+      let environment         =   AlLocatorService.getCurrentEnvironment();
+      let accountId           =   requestParams.context_account_id || requestParams.account_id || this.defaultAccountId || "0";
+      let serviceEndpointId   =   requestParams.target_endpoint || requestParams.service_name;
+      let residency           =   requestParams.residency ?? "default";
+      let residencyAware      =   AlApiClient.resolveByResidencyServiceList.includes( serviceEndpointId )
+                                    || ! [ undefined, null, 'default' ].includes( requestParams.residency );      //  specific residency zone forces residency aware lookup
+
       if ( residencyAware && residency === 'default' ) {
           residency = AlLocatorService.getCurrentResidency();
+      } else if ( residency !== 'default' ) {
+          residencyAware = true;
       }
+
       let baseURL = getJsonPath<string>( this.endpointCache,
                                          [ environment, accountId, serviceEndpointId, residency ],
                                          null );


### PR DESCRIPTION
Slightly tweaks the behavior of the base API client's `prepare()` function to use residency-aware lookups for specific residency zones, even if they are not in the default list of residency-aware services. This allows the original default behavior to remain, but lets individual client methods choose their type of residency behavior on a case-by-case basis.