### PR TITLE
ENG-0000 - Add Runtime Configuration for Link Truncation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/configuration/al-runtime-configuration.ts
+++ b/src/configuration/al-runtime-configuration.ts
@@ -74,6 +74,7 @@ export interface AlContextOptions {
     embeddedFortraApp?:boolean;
     externalConduitIFrame?:string;
     defaultAccountId?:string;
+    truncateLocalLinks?:boolean;
 }
 
 /**

--- a/src/error-handler/al-error-handler.ts
+++ b/src/error-handler/al-error-handler.ts
@@ -1,7 +1,6 @@
 import { AxiosResponse } from 'axios';
-import { AlBaseError, AlAPIServerError, AlWrappedError, AlCabinet } from '../common';
+import { AlBaseError, AlAPIServerError, AlWrappedError, AlCabinet, AlGlobalizer } from '../common';
 import { AlDefaultClient, APIRequestParams } from '../client';
-import { AlGlobalizer } from '../common';
 
 export interface AlErrorDescriptor {
     title:string;
@@ -33,6 +32,12 @@ export class AlErrorHandler
     public static log( error:AxiosResponse|AlBaseError|Error|string|any, commentary?:string, categoryId?:string, overrideVerbosity?:boolean ) {
         AlErrorHandler.prepare();
         const normalized = AlErrorHandler.normalize( error );
+        if ( typeof error === 'string' && typeof categoryId === 'string'
+                    &&
+             ! commentary.includes(" ") && commentary.toLowerCase() === commentary && commentary.length < 32 ) {
+            categoryId = commentary;
+            commentary = undefined;
+        }
         const effectiveCategoryId = categoryId ?? 'general';
         if ( overrideVerbosity || AlErrorHandler.verbose || AlErrorHandler.categories.includes( effectiveCategoryId ) ) {
             console.log( commentary ? `${commentary}: ${normalized.message}` : normalized.message );

--- a/src/navigation/al-route.types.ts
+++ b/src/navigation/al-route.types.ts
@@ -6,6 +6,7 @@
  */
 
 import { AlLocatorService } from './locator.service';
+import { AlRuntimeConfiguration } from '../configuration';
 
 /**
  * @public
@@ -243,7 +244,10 @@ class AlRouteIterationState {
 
     constructor( public rootNode:AlRoute,
                  public resolve:boolean = false,
-                 public truncateLocal:boolean = false ) {
+                 public truncateLocal?:boolean ) {
+        if ( typeof this.truncateLocal === undefined ) {
+            this.truncateLocal = !! AlRuntimeConfiguration.options.truncateLocalLinks;
+        }
         this.host = rootNode.host;
         this.url = rootNode.host.currentUrl;
         let hashOffset = this.url.indexOf("#");
@@ -388,7 +392,7 @@ export class AlRoute {
      *
      * @returns Returns true if the route (or one of its children) is activated, false otherwise.
      */
-    refresh( resolve:boolean = false, truncateLocalURLs:boolean = false ) {
+    refresh( resolve:boolean = false, truncateLocalURLs?:boolean ) {
         try {
             let state = new AlRouteIterationState( this, resolve, truncateLocalURLs );
             this.internalRefresh( state );

--- a/src/navigation/location-dictionary.ts
+++ b/src/navigation/location-dictionary.ts
@@ -85,9 +85,10 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
     {
         locTypeId: AlLocation.InsightAPI,
         uri: 'https://api.product.dev.alertlogic.com',
-        environment: 'integration|development',
+        environment: 'integration|development|embedded-integration|embedded-development',
         residency: 'US',
     },
+    /*
     {
         locTypeId: AlLocation.InsightAPI,
         uri: 'https://api.xdr.foundation-stage.cloudops.fortradev.com',
@@ -100,6 +101,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         environment: 'embedded-development',
         residency: 'US',
     },
+    */
 
     /**
      * Gestalt api API locations


### PR DESCRIPTION
Defaults to off.  It is is enable, the routing layer will reduce any links it generates to itself to only the anchor fragment and query string.  Hypothetically, this should universally be the case -- and if it auditions well in the embedded fortra-platform version of magma it should soon become so.