### PR TITLE
ENG-0000 - Update `AlSession` to enforce non-zero account Id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -120,9 +120,12 @@ export class AlSessionInstance
        * API requests from being fired before whatever application has imported us has had a chance to bootstrap.
        */
       const persistedSession = this.storage.get("session") as AIMSSessionDescriptor;
-      if ( persistedSession && persistedSession.hasOwnProperty( "authentication" ) && persistedSession.authentication.token_expiration >= this.getCurrentTimestamp() ) {
+      if ( ( persistedSession?.authentication?.token_expiration ?? 0 ) >= this.getCurrentTimestamp()
+                &&
+            persistedSession?.authentication?.account?.id ) {
         this.restoreSession( persistedSession );
       } else {
+          console.warn("TOTALLY IGNORING STORED SESSSION!" );
         this.storage.destroy();
       }
 
@@ -776,7 +779,7 @@ export class AlSessionInstance
 
         return this.resolvedAccount;
       } catch( e ) {
-        console.error( e );
+        console.error( "FAILED to resolve acting account!", e );
         throw e;
       }
     }


### PR DESCRIPTION
This updates `AlSession`'s constructor to enforce both timestamps and account IDs for session information found in localStorage.