### PR TITLE
ENG-0000 - Update `AlSession` to enforce non-zero account Id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/navigation/constants.ts
+++ b/src/navigation/constants.ts
@@ -118,6 +118,9 @@ export class AlLocation
                 locTypeId: locTypeId,
                 environment: 'embedded-development',
                 uri: `https://foundation.foundation-dev.cloudops.fortradev.com/*/`,
+                aliases: [
+                    `https://local.foundation.foundation-dev.cloudops.fortradev.com:8888/*/`
+                ]
             },
             {
                 locTypeId: locTypeId,

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -259,6 +259,12 @@ export class AlSessionInstance
         const accountDetails = await AIMSClient.getAccountDetails( account );
         return await this.setActingAccount( accountDetails );
       }
+      if ( account.id === '0' ) {
+        //  This case may occur in embedded mode, after we consider ourselves authenticated but BEFORE we have resolved the
+        //  acting user to a distinct alertlogic account Id.  Just smile and wave...
+        this.resolvedAccount = new AlActingAccountResolvedEvent( account, new AlEntitlementCollection(), new AlEntitlementCollection() );
+        return Promise.resolve( this.resolvedAccount );
+      }
       const previousAccount               = this.sessionData.acting;
       const mustResolveAccount            = ! this.sessionData.acting
                                               || this.sessionData.acting.id !== account.id;


### PR DESCRIPTION
This updates `AlSession`'s constructor to enforce both timestamps and account IDs for session information found in localStorage.