### PR TITLE
ENG-0000 - Updated Location Dictionary with internal API bases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/navigation/al-route.types.ts
+++ b/src/navigation/al-route.types.ts
@@ -6,7 +6,6 @@
  */
 
 import { AlLocatorService } from './locator.service';
-import { AlRuntimeConfiguration } from '../configuration';
 
 /**
  * @public
@@ -246,7 +245,7 @@ class AlRouteIterationState {
                  public resolve:boolean = false,
                  public truncateLocal?:boolean ) {
         if ( typeof this.truncateLocal === undefined ) {
-            this.truncateLocal = !! AlRuntimeConfiguration.options.truncateLocalLinks;
+            this.truncateLocal = AlRoute.truncateLocalURLs;
         }
         this.host = rootNode.host;
         this.url = rootNode.host.currentUrl;
@@ -271,6 +270,9 @@ class AlRouteIterationState {
  */
 export class AlRoute {
     public static debug:boolean = false;
+
+    /* If true, removes all but the anchor fragment of URLs on the "acting" node */
+    public static truncateLocalURLs:boolean = false;
 
     /* A global cache of compiled regexes for match checking */
     public static reCache:{[pattern:string]:RegExp|null} = {};
@@ -388,13 +390,12 @@ export class AlRoute {
      * simply wraps the tree iteration process in exception handling.
      *
      * @param resolve - If true, forces the calculated href and visibility properties to be recalculated.
-     * @param truncateLocalURLs - If true, removes all but the anchor fragment of URLs on the "acting" node
      *
      * @returns Returns true if the route (or one of its children) is activated, false otherwise.
      */
-    refresh( resolve:boolean = false, truncateLocalURLs?:boolean ) {
+    refresh( resolve:boolean = false ) {
         try {
-            let state = new AlRouteIterationState( this, resolve, truncateLocalURLs );
+            let state = new AlRouteIterationState( this, resolve, AlRoute.truncateLocalURLs );
             this.internalRefresh( state );
         } catch( e ) {
             console.error(`Navigation Error: could not refresh menu: `, e );
@@ -520,8 +521,8 @@ export class AlRoute {
     /**
      * Retrieves the full URL for a route, if applicable.
      */
-    toHref( truncateLocalURLs?:boolean ) {
-        this.refresh( true, truncateLocalURLs );
+    toHref() {
+        this.refresh( true );
         return this.href;
     }
 

--- a/src/navigation/constants.ts
+++ b/src/navigation/constants.ts
@@ -113,6 +113,10 @@ export class AlLocation
                 locTypeId: locTypeId,
                 environment: 'development',
                 uri: `http://localhost:${devPort}`,
+                aliases: [
+                    `http://localhost:8916`,
+                    `http://localhost:8917`
+                ]
             },
             {
                 locTypeId: locTypeId,

--- a/src/navigation/location-dictionary.ts
+++ b/src/navigation/location-dictionary.ts
@@ -53,19 +53,24 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         locTypeId: AlLocation.GlobalAPI,
         insightLocationId: 'insight-global',
         uri: 'https://api.global-integration.product.dev.alertlogic.com',
-        environment: 'integration|development|embedded-development|embedded-integration',
-/*        environment: 'integration|development', */
+//        environment: 'integration|development|embedded-development|embedded-integration',
+        environment: 'integration|development',
         external: true
     },
-/*
     {
         locTypeId: AlLocation.GlobalAPI,
         insightLocationId: 'insight-global',
-        uri: 'https://api.xdr.foundation-dev.cloudops.fortradev.com',
+        uri: 'https://api.global.xdr.foundation-stage.cloudops.fortradev.com',
+        environment: 'embedded-integration',
+        external: true
+    },
+    {
+        locTypeId: AlLocation.GlobalAPI,
+        insightLocationId: 'insight-global',
+        uri: 'https://api.global.xdr.foundation-dev.cloudops.fortradev.com',
         environment: 'embedded-development|embedded-integration',
         external: true
     },
-*/
 
     /**
     *  Cloud Insight API locations
@@ -85,10 +90,10 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
     {
         locTypeId: AlLocation.InsightAPI,
         uri: 'https://api.product.dev.alertlogic.com',
-        environment: 'integration|development|embedded-integration|embedded-development',
+//        environment: 'integration|development|embedded-integration|embedded-development',
+        environment: 'integration|development',
         residency: 'US',
     },
-    /*
     {
         locTypeId: AlLocation.InsightAPI,
         uri: 'https://api.xdr.foundation-stage.cloudops.fortradev.com',
@@ -101,7 +106,6 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         environment: 'embedded-development',
         residency: 'US',
     },
-    */
 
     /**
      * Gestalt api API locations

--- a/test/common/al-route.spec.ts
+++ b/test/common/al-route.spec.ts
@@ -146,13 +146,15 @@ describe( 'AlRoute', () => {
             expect( routeHref ).to.equal( 'https://another.unrealdomain.com/other/subdirectory/#/some/random/path' );
         } );
         it("should use localized URLs when configured to do so", () => {
+            AlRoute.truncateLocalURLs = true;
             const route = AlRoute.link( routingHost, AlLocation.MagmaUI, '/#/just/an/anchor/tag' );
-            let routeHref = route.toHref( true );
+            let routeHref = route.toHref();
             expect( routeHref ).to.equal( '#/just/an/anchor/tag' );
 
             const externalRoute = AlRoute.link( routingHost, AlLocation.OverviewUI, '/#/just/an/anchor/tag' );
-            let externalHref = externalRoute.toHref( true );
+            let externalHref = externalRoute.toHref();
             expect( externalHref ).to.equal("https://console.overview.alertlogic.com/#/just/an/anchor/tag" );
+            AlRoute.truncateLocalURLs = false;
         } );
     } );
 
@@ -444,13 +446,15 @@ describe( 'AlRoute', () => {
         } );
 
         it( "should truncate local links to include only their anchor fragment", () => {
+            AlRoute.truncateLocalURLs = true;
             const menu:AlRoute = new AlRoute( routingHost, menuDefinition );
-            menu.refresh( true, true );
+            menu.refresh( true );
             let route1 = menu.children[0].children[0];
             let route2 = menu.children[0].children[1];
 
             expect( route1.href ).to.equal( '#/child-route-1' );
             expect( route2.href ).to.equal( 'https://console.incidents.alertlogic.com/#/child-route-2' );
+            AlRoute.truncateLocalURLs = false;
         } );
     } );
 

--- a/test/error-handler/al-error-handler.spec.ts
+++ b/test/error-handler/al-error-handler.spec.ts
@@ -24,14 +24,14 @@ describe('AlErrorHandler', () => {
             sinon.restore();
         } );
         it("Should handle any input without blowing up", () => {
-            AlErrorHandler.verbose = true;
+            AlErrorHandler.enable( "*" );
             AlErrorHandler.log( http404Response, "Got a weird response" );
             AlErrorHandler.log( new AlBaseError( "Something is rotten in the state of Denmark." ) );
             AlErrorHandler.log( new Error("Something stinks under the kitchen sink." ) );
             AlErrorHandler.log( "Throwing strings as Errors is silly and should never be done, but what can you do?", "Some comment" );
             AlErrorHandler.log( 42 );
             expect( logStub.callCount ).to.equal( 5 );  //  1 for each .log call
-            AlErrorHandler.verbose = false;
+            AlErrorHandler.disable( "*" );
             AlErrorHandler.log( "This should not get emitted" );
             expect( logStub.callCount ).to.equal( 5 );  //  1 for each .log call
         } );


### PR DESCRIPTION
This change will cause embedded instances of the XDR console to use .fortra domains.

For `embedded-development` environment:
    Global: api.global.xdr.foundation-dev.cloudops.fortradev.com
    Regional: api.xdr.foundation-dev.cloudops.fortradev.com

For `embedded-integration` environment:
    Global: api.global.xdr.foundation-stage.cloudops.fortradev.com
    Regional: api.xdr.foundation-stage.cloudops.fortradev.com

Also gave AlErrorHandler a nice little overhaul, allowing logs to be emitted to specific categories which can be enable or disabled via terminal commands.

This enables all: `al.error.enable("*")`
This disables all: `al.error.disable("*")`