### PR TITLE
ENG-0000 - Target AIMS Global Stack/Token Info via cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/aims-client/aims-client.ts
+++ b/src/aims-client/aims-client.ts
@@ -2,6 +2,7 @@
  * Module to deal with available AIMS Public API endpoints
  */
 
+import { AlRuntimeConfiguration } from '../configuration';
 import {
     AlApiClient,
     AlDefaultClient,
@@ -50,7 +51,7 @@ export class AIMSClientInstance {
    */
   async createUser(accountId: string, name: string, email: string, mobilePhone: string) {
     const user = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -69,7 +70,7 @@ export class AIMSClientInstance {
    */
   async createUserWithDetails(accountId: string, userDetails:AIMSUserDetails) {
     return this.client.post<AIMSUser>({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -86,7 +87,7 @@ export class AIMSClientInstance {
    */
   async updateUserDetails(accountId: string, userId: string, data:AIMSUserDetails):Promise<AIMSUser> {
     const userDetailsUpdate = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -104,7 +105,7 @@ export class AIMSClientInstance {
    */
   async deleteUser(accountId: string, userId: string) {
     const userDelete = await this.client.delete({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -132,7 +133,7 @@ export class AIMSClientInstance {
    */
   async getUserDetailsById(accountId: string, userId: string) {
     const userDetails = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -144,7 +145,7 @@ export class AIMSClientInstance {
 
   async getUserDetailsByUserId(userId: string) {
     const userDetails = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: `/user/${userId}`
@@ -181,7 +182,7 @@ export class AIMSClientInstance {
    */
   async getUserPermissions(accountId: string, userId: string) {
     const userPermissions = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -199,7 +200,7 @@ export class AIMSClientInstance {
    */
   async getAccountDetails(accountId: string) {
     const accountDetails = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -241,7 +242,7 @@ export class AIMSClientInstance {
    */
   async getAccountIdsByRelationship(accountId: string, relationship: string, queryParams?):Promise<string[]> {
     const accountIds = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -262,7 +263,7 @@ export class AIMSClientInstance {
    */
   async getAccountsByRelationship(accountId: string, relationship: string, queryParams?):Promise<AIMSAccount[]> {
     const managedAccounts = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -305,7 +306,7 @@ export class AIMSClientInstance {
    */
   async requireMFA(accountId: string, mfaRequired: boolean):Promise<AIMSAccount> {
     const account = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -359,7 +360,7 @@ export class AIMSClientInstance {
    */
   async changePassword(email: string, password: string, newPassword: string) {
     const changePass = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: '/change_password',
@@ -379,7 +380,7 @@ export class AIMSClientInstance {
    */
   async tokenInfo() {
     const tokenData = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: '/token_info',
@@ -400,13 +401,15 @@ export class AIMSClientInstance {
       ttl: 10 * 60 * 1000,
       cacheKey: AlLocatorService.resolveURL( AlLocation.GlobalAPI, `/aims/v1/token_info/${accessToken}` )       //  custom cacheKey to avoid cache pollution
     };
-    if ( useAuthenticationHeader ) {
-      request.headers['Authorization'] = `Bearer ${accessToken}`;
-      if ( AlLocatorService.getCurrentEnvironment() === 'embedded-development' ) {
-        request.headers['X-Fortra-Environment'] = "dev";
-      }
-    } else {
-      request.headers['X-AIMS-Auth-Token'] = accessToken;
+    if ( ! AlRuntimeConfiguration.options.embeddedFortraApp ) {
+        if ( useAuthenticationHeader ) {
+          request.headers['Authorization'] = `Bearer ${accessToken}`;
+          if ( AlLocatorService.getCurrentEnvironment() === 'embedded-development' ) {
+            request.headers['X-Fortra-Environment'] = "dev";
+          }
+        } else {
+          request.headers['X-AIMS-Auth-Token'] = accessToken;
+        }
     }
     return await this.client.get( request );
   }
@@ -419,7 +422,7 @@ export class AIMSClientInstance {
    */
   async initiateReset(email: string, returnTo: string) {
     const reset = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: '/reset_password',
@@ -436,7 +439,7 @@ export class AIMSClientInstance {
    */
   async resetWithToken(token: string, password: string) {
     const reset = await this.client.put({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: `/reset_password/${token}`,
@@ -453,7 +456,7 @@ export class AIMSClientInstance {
    */
   async createRole(accountId: string, name: string, permissions) {
     const createRole = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -471,7 +474,7 @@ export class AIMSClientInstance {
    */
   async deleteRole(accountId: string, roleId: string) {
     const roleDelete = await this.client.delete({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -488,7 +491,7 @@ export class AIMSClientInstance {
    */
   async grantRole(accountId:string, userId:string, roleId:string) {
     return this.client.put({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -504,7 +507,7 @@ export class AIMSClientInstance {
    */
   async revokeRole(accountId:string, userId:string, roleId:string) {
     return this.client.delete({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -520,7 +523,7 @@ export class AIMSClientInstance {
    */
   async getGlobalRole(roleId: string) {
     const role = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: `/roles/${roleId}`
@@ -536,7 +539,7 @@ export class AIMSClientInstance {
    */
   async getAccountRole(accountId: string, roleId: string) {
     const role = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -553,7 +556,7 @@ export class AIMSClientInstance {
    */
   async getAssignedRoles( accountId:string, userId:string ):Promise<AIMSRole[]> {
     const roles = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -570,7 +573,7 @@ export class AIMSClientInstance {
    */
   async getGlobalRoles():Promise<AIMSRole[]> {
     const roles = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: '/roles'
@@ -586,7 +589,7 @@ export class AIMSClientInstance {
    */
   async getAccountRoles(accountId: string):Promise<AIMSRole[]> {
     const roles = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -603,7 +606,7 @@ export class AIMSClientInstance {
    */
   async updateRole(accountId: string, name: string, permissions) {
     const roleUpdate = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -620,7 +623,7 @@ export class AIMSClientInstance {
    */
   async updateRoleName(accountId: string, name: string) {
     const updateRole = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -637,7 +640,7 @@ export class AIMSClientInstance {
    */
   async updateRolePermissions(accountId: string, permissions) {
     const updateRole = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -663,7 +666,7 @@ export class AIMSClientInstance {
    */
   async enrollMFA( uri: string, sessionToken:string, codes:string[] ) {
     const mfa = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: '/user/mfa/enroll',
@@ -693,7 +696,7 @@ export class AIMSClientInstance {
    */
   async enrollMFAWithoutAIMSToken(uri:AIMSEnrollURI, codes:string[], email:string, password:string ) {
     return this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: '/user/mfa/enroll',
@@ -715,7 +718,7 @@ export class AIMSClientInstance {
    */
   async deleteMFA(email: string) {
     const mfa = await this.client.delete({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: `/user/mfa/${email}`,
@@ -725,7 +728,7 @@ export class AIMSClientInstance {
 
   getUserDetails(accountId: string, userId: string, queryParams?: {include_role_ids?: boolean, include_user_credential?: boolean}): Promise<AIMSUser> {
     return this.client.get<AIMSUser>({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -743,7 +746,7 @@ export class AIMSClientInstance {
   async getUsers( accountId: string,
                   queryParams?: {include_role_ids?: boolean, include_user_credential?: boolean} ):Promise<AIMSUser[]> {
     const users = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -762,7 +765,7 @@ export class AIMSClientInstance {
    */
   async createAccessKey(accountId: string, userId: string, label: string) {
     const key = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -781,7 +784,7 @@ export class AIMSClientInstance {
    */
   async updateAccessKey(accessKeyId: string, label: string) {
     const key = await this.client.post({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: `/access_keys/${accessKeyId}`,
@@ -798,7 +801,7 @@ export class AIMSClientInstance {
    */
   async getAccessKey(accessKeyId: string) {
     const key = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: `/access_keys/${accessKeyId}`
@@ -814,7 +817,7 @@ export class AIMSClientInstance {
    */
   async getAccessKeys(accountId: string, userId: string, ttl: number = 60000) {
     const keys = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -832,7 +835,7 @@ export class AIMSClientInstance {
    */
   async deleteAccessKey(accountId: string, userId: string, accessKeyId: string) {
     const keyDelete = await this.client.delete({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -846,7 +849,7 @@ export class AIMSClientInstance {
    */
   async getAccountOrganization( accountId:string ):Promise<AIMSOrganization> {
       const requestDescriptor = {
-          service_stack: AlLocation.InsightAPI,
+          service_stack: AlLocation.GlobalAPI,
           service_name: this.serviceName,
           version: 1,
           account_id: accountId,
@@ -860,7 +863,7 @@ export class AIMSClientInstance {
    */
   async getLicenseAcceptanceStatus( accountId:string ):Promise<AIMSLicenseAcceptanceStatus> {
       return await this.client.get( {
-          service_stack: AlLocation.InsightAPI,
+          service_stack: AlLocation.GlobalAPI,
           service_name: this.serviceName,
           version: 1,
           account_id: accountId,
@@ -873,7 +876,7 @@ export class AIMSClientInstance {
    */
   async setLicenseAcceptance( accountId:string, accepted:boolean ) {
       return await this.client.post( {
-          service_stack: AlLocation.InsightAPI,
+          service_stack: AlLocation.GlobalAPI,
           service_name: this.serviceName,
           version: 1,
           account_id: accountId,
@@ -896,7 +899,7 @@ export class AIMSClientInstance {
    */
   async getAccountRelationshipTopology(accountId: string, relationship: 'managed' | 'managing', queryParams?): Promise<AIMSTopology> {
     const response = await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       account_id: accountId,
@@ -930,7 +933,7 @@ export class AIMSClientInstance {
    */
   async getFrontlineMigrationStatus( accountId:string ):Promise<{import_status: "PENDING"|"RUNNING"|"COMPLETED"|"ERRORED",import_details:any}> {
       return await this.client.get( {
-          service_stack: AlLocation.InsightAPI,
+          service_stack: AlLocation.GlobalAPI,
           service_name: this.serviceName,
           version: this.serviceVersion,
           account_id: accountId,
@@ -944,7 +947,7 @@ export class AIMSClientInstance {
    */
   async getMappedAccount(accountId: string): Promise<AIMSMappedAccount> {
     return await this.client.get({
-      service_stack: AlLocation.InsightAPI,
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: this.serviceVersion,
       path: `/${accountId}/mapping`
@@ -956,7 +959,7 @@ export class AIMSClientInstance {
    */
   async startFrontlineMigration( accountId:string ):Promise<boolean> {
       return await this.client.post( {
-          service_stack: AlLocation.InsightAPI,
+          service_stack: AlLocation.GlobalAPI,
           service_name: this.serviceName,
           version: this.serviceVersion,
           account_id: accountId,

--- a/test/aims-client/aims-client.spec.ts
+++ b/test/aims-client/aims-client.spec.ts
@@ -19,13 +19,12 @@ const queryParams = { foo: 'bar' };
 
 describe('AIMS Client Test Suite:', () => {
   let stub: sinon.SinonSpy;
-  let apiBaseURL, globalBaseURL;
+  let globalBaseURL;
   beforeEach(() => {
     AlLocatorService.setContext( { environment: "integration" } );
     AlDefaultClient.reset()
             .setGlobalParameters( { noEndpointsResolution: true } );
     stub = sinon.stub(AlDefaultClient as any, "axiosRequest").returns( Promise.resolve( { status: 200, data: 'Some result', config: {} } ) );
-    apiBaseURL = AlLocatorService.resolveURL( AlLocation.InsightAPI );
     globalBaseURL = AlLocatorService.resolveURL( AlLocation.GlobalAPI );
   });
   afterEach(() => {
@@ -46,7 +45,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/users` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/users` );
       expect( payload.data ).to.deep.equal( { name, email, mobile_phone: mobilePhone } );
     });
   });
@@ -56,7 +55,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "DELETE" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/users/${userId}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/users/${userId}` );
     });
   });
   describe('when retrieving a user record', () => {
@@ -65,7 +64,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/users/${userId}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/users/${userId}` );
     });
   });
   describe('when retrieving permissions for a user', () => {
@@ -74,7 +73,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/users/${userId}/permissions` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/users/${userId}/permissions` );
     });
   });
   describe('when retrieving account details', () => {
@@ -83,7 +82,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/account` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/account` );
     });
   });
   describe('when retrieving managed account details', () => {
@@ -92,7 +91,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/accounts/managed` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/accounts/managed` );
     });
   });
   describe('when retrieving managed account Ids', () => {
@@ -101,7 +100,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/account_ids/managed` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/account_ids/managed` );
     });
   });
   describe('when retrieving managing account Id', () => {
@@ -110,7 +109,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/account_ids/managing` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/account_ids/managing` );
     });
   });
   describe('when retrieving managing accounts', () => {
@@ -119,7 +118,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/accounts/managing` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/accounts/managing` );
     });
   });
   describe('when enabling MFA for a user account', () => {
@@ -129,7 +128,7 @@ describe('AIMS Client Test Suite:', () => {
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
       expect( payload.data ).to.deep.equal( { mfa_required: true } );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/account` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/account` );
     });
   });
   describe('when authenticating a user', () => {
@@ -163,7 +162,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/change_password` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/change_password` );
       expect( payload.data ).to.deep.equal( { email, current_password: password, new_password: newPassword } );
     });
   });
@@ -173,7 +172,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/token_info` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/token_info` );
     });
   });
   describe("when retrieving token info for a specific token", () => {
@@ -194,7 +193,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/reset_password` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/reset_password` );
       expect( payload.data ).to.deep.equal( { email, return_to: returnTo } );
     });
   });
@@ -206,7 +205,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "PUT" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/reset_password/${token}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/reset_password/${token}` );
       expect( payload.data ).to.deep.equal( { password } );
     });
   });
@@ -218,7 +217,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/roles` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/roles` );
       expect( payload.data ).to.deep.equal( { name, permissions } );
     });
   });
@@ -229,7 +228,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "DELETE" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/roles/${roleId}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/roles/${roleId}` );
     });
   });
   describe('when retrieving a global role', () => {
@@ -239,7 +238,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/roles/${roleId}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/roles/${roleId}` );
     });
   });
   describe('when retrieving an account role', () => {
@@ -249,7 +248,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/roles/${roleId}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/roles/${roleId}` );
     });
   });
   describe('when retrieving all global roles', () => {
@@ -258,7 +257,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/roles` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/roles` );
     });
   });
   describe('when retrieving all account roles', () => {
@@ -267,7 +266,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/roles` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/roles` );
     });
   });
   describe('when updating the name and permissions of a role', () => {
@@ -278,7 +277,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/roles` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/roles` );
     });
   });
   describe('when updating the name of a role', () => {
@@ -288,7 +287,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/roles` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/roles` );
       expect( payload.data ).to.deep.equal( { name } );
     });
   });
@@ -299,7 +298,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/roles` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/roles` );
       expect( payload.data ).to.deep.equal( { permissions } );
     });
   });
@@ -311,7 +310,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/user/mfa/enroll` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/user/mfa/enroll` );
       expect( payload.data ).to.deep.equal( { mfa_uri: uri, mfa_codes: codes } );
     });
   });
@@ -322,7 +321,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "DELETE" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/user/mfa/${email}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/user/mfa/${email}` );
     });
   });
   describe('when retrieving user details', () => {
@@ -332,7 +331,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/users/${userId}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/users/${userId}` );
     });
   });
   describe('when retrieving users', () => {
@@ -342,7 +341,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/users` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/users` );
     });
   });
   describe('when creating an access key', () => {
@@ -352,7 +351,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/users/${userId}/access_keys` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/users/${userId}/access_keys` );
       expect( payload.data ).to.deep.equal( { label } );
     });
   });
@@ -364,7 +363,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "POST" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/access_keys/${accessKeyId}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/access_keys/${accessKeyId}` );
       expect( payload.data ).to.deep.equal( { label } );
     });
   });
@@ -375,7 +374,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/access_keys/${accessKeyId}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/access_keys/${accessKeyId}` );
     });
   });
   describe('when retrieving all access keys for a user', () => {
@@ -384,7 +383,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/users/${userId}/access_keys?out=full` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/users/${userId}/access_keys?out=full` );
     });
   });
   describe('when deleting an access key for a user', () => {
@@ -394,7 +393,7 @@ describe('AIMS Client Test Suite:', () => {
       expect(stub.callCount).to.equal(1);
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "DELETE" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/${accountId}/users/${userId}/access_keys/${accessKeyId}` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/${accountId}/users/${userId}/access_keys/${accessKeyId}` );
     });
   });
   describe( 'AIMSEnrollURI', () => {


### PR DESCRIPTION
Updates all AIMS endpoints to use the global rather than local stack. According to James, this should have always been the case; the local stack redirects internally to the global one, but it is less efficient.

Updated the token_info endpoint to omit any explicit token when running as a plugin.