### PR TITLE
ENG-58489 - Always Resolve New Accounts to their Default Datacenter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/session/al-session.ts
+++ b/src/session/al-session.ts
@@ -275,9 +275,7 @@ export class AlSessionInstance
 
       this.sessionData.acting             = account;
 
-      const targetLocationId              = account.accessible_locations.indexOf( this.sessionData.boundLocationId ) !== -1
-                                              ? this.sessionData.boundLocationId
-                                              : account.default_location;
+      const targetLocationId              = account.default_location;   /* ENG-58489 - always use account default location */
       this.setActiveDatacenter( targetLocationId );
 
       AlDefaultClient.defaultAccountId    = account.id;


### PR DESCRIPTION
Replaces the previous behavior, in which it was possible to switch to a new account in a DC other than their default (e.g., Ashburn instead of Denver or Newport instead of Ashburn) because it was within their AIMS `accessible_locations` array.