### PR TITLE
ENG-58506 - Open Link in a New Tab fails randomly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/error-handler/al-error-handler.ts
+++ b/src/error-handler/al-error-handler.ts
@@ -69,8 +69,16 @@ export class AlErrorHandler
      * @returns AlBaseError of the appropriate flavor.
      */
     public static normalize( error:AxiosResponse|AlBaseError|Error|string|any, commentary?:string ):AlBaseError {
-        if ( error instanceof AlBaseError ) {
+        if ( error === undefined || error === null ) {
+            return new AlBaseError( `An undefined or null value was thrown as an error` );
+        } else if ( error instanceof AlBaseError ) {
             return error;
+        } else if ( error instanceof Error ) {
+            let message = error.message ?? "Unspecified error";
+            if ( commentary ) {
+                message = `${commentary}: ${message}`;
+            }
+            return new AlBaseError( message, error );
         } else if ( AlDefaultClient.isResponse( error ) ) {
             let config = error.config as APIRequestParams;
             let serviceName = `service_name` in config ? config.service_name : config.url;
@@ -80,12 +88,6 @@ export class AlErrorHandler
                 errorText = `${commentary}: ${errorText}`;
             }
             return new AlAPIServerError( errorText, serviceName, statusCode, error );
-        } else if ( error instanceof Error ) {
-            let message = error.message;
-            if ( commentary ) {
-                message = `${commentary}: ${error.message}`;
-            }
-            return new AlBaseError( message, error );
         } else if ( typeof( error ) === 'string' ) {
             if ( commentary ) {
                 error = `${commentary}: ${error}`;


### PR DESCRIPTION
Actually, semi-randomly.  The keycloak-js `updateToken()` method is throwing `undefined` as an exception for its own twisted reasons.  Our top-level XHR model does not handle thrown exceptions within its `beforeRequest` callback.  This caused the error handler and the API client to both choke to death.  SO SAD.