### PR TITLE
ENG-0000 - Expanded convert_token functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This extends `AlAuthenticationUtility` as follows:

  - In addition to the existing `convertFortraToken` method, a new
    `convertFortraSession` method exists on `AlAuthenticationUtility`,
    returning the complete token_info payload of the response.;
  - Requests are debounced, such that only one outbound request can be
    made at a time;
  - Request responses are cached in a static property.
