### PR TITLE
ENG-0000 - Enable New Integration Domains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/navigation/constants.ts
+++ b/src/navigation/constants.ts
@@ -53,9 +53,9 @@ export class AlLocation
     public static IntegrationsUI    = "cd17:integrations";      //  deprecated
     public static EndpointsUI       = "cd19:endpoints";
     public static InsightBI         = "insight:bi";
-    public static HudUI             = "insight:hud"; // deprecated by SOC UI
-    public static IrisUI            = "insight:iris"; // deprecated by SOC UI
-    public static SOCUI             = "cd21:soc";
+    public static HudUI             = "insight:hud";            //  deprecated by SOC UI
+    public static IrisUI            = "insight:iris";           //  deprecated by SOC UI
+    public static SOCUI             = "cd25:soc";               //  such sparkles
     public static SearchUI          = "cd17:search";            //  almost deprecated
     public static HealthUI          = "cd17:health";            //  deprecated
     public static DisputesUI        = "cd17:disputes";          //  deprecated
@@ -81,24 +81,23 @@ export class AlLocation
     public static GoogleTagManager  = "gtm";
     public static DatadogRum        = "datadogrum";
 
-    public static socNode( locTypeId:string, appCode:string, devPort:number ):AlLocationDescriptor[] {
+    public static socNode( locTypeId:string, devPort:number ):AlLocationDescriptor[] {
         return [
             {
                 locTypeId: locTypeId,
                 environment: 'production',
                 residency: 'US',
-                uri: `https://console.${appCode}.alertlogic.com`,
+                uri: `https://master.soc-ui.product.dev.alertlogic.com`,
             },
             {
                 locTypeId: locTypeId,
                 environment: 'integration',
-                uri: `https://console.${appCode}.product.dev.alertlogic.com`,
-                aliases: [`https://${appCode}.dev.product.dev.alertlogic.com`],
+                uri: `https://integration.soc-ui.product.dev.alertlogic.com`
             },
             {
                 locTypeId: locTypeId,
                 environment: 'development',
-                uri: `http://localhost:${devPort}/#/${appCode}`,
+                uri: `http://localhost:${devPort}`,
             }
         ];
     }
@@ -135,7 +134,8 @@ export class AlLocation
                 aliases: [
                     `https://${appCode}.ui-dev.product.dev.alertlogic.com`,
                     `https://${appCode}-*.ui-dev.product.dev.alertlogic.com`,
-                    `https://${appCode}-pr-*.ui-dev.product.dev.alertlogic.com`
+                    `https://${appCode}-pr-*.ui-dev.product.dev.alertlogic.com`,
+                    `https://*.xdr-ui.product.dev.alertlogic.com`
                 ],
                 data: {
                     mapboxToken: 'pk.eyJ1IjoidWktdGVhbSIsImEiOiJjbThnMnZmMGUwaW13Mmlwd3I0em5zM3BjIn0.whlbgkSaGpcynFS_gTFbsA'

--- a/src/navigation/location-dictionary.ts
+++ b/src/navigation/location-dictionary.ts
@@ -10,8 +10,7 @@ import { AlLocation } from './constants';
 export const AlLocationDictionary: AlLocationDescriptor[] =
 [
     ...AlLocation.magmaNode(AlLocation.MagmaUI, 'magma', 8888 ),
-    ...AlLocation.socNode(AlLocation.SOCUI, 'iris', 4202),
-    ...AlLocation.socNode(AlLocation.SOCUI, 'hud', 4202),
+    ...AlLocation.socNode(AlLocation.SOCUI, 4202),
     ...AlLocation.o3Node(AlLocation.AccountsUI, 'account', 8002),
     ...AlLocation.o3Node(AlLocation.OverviewUI, 'overview', 4213),
     ...AlLocation.o3Node(AlLocation.IncidentsUI, 'incidents', 8001),


### PR DESCRIPTION
New integration/feature-branch/PR builds for the existing XDR console will be deployed to
`https://{variant}.xdr-ui.product.dev.alertlogic.com`.  This is current an alias, but should become the default identity for integration moving forward.

Soc UI deployments will be made available at
`https://{varient}.soc-ui.product.dev.alertlogic.com`.

Last but not least, plugin versions of the XDR console will be published to `https://{variant}.xdr-plugin.product.dev.alertlogic.com`.