### PR TITLE
VTT-7160 - Tweak Account Resolution Error Handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
In practice, this change will nuke any residual session state if `AlSession` cannot resolve all of the account and entitlement info it needs when it is being constructed and rehydrated from localStorage.