### PR TITLE
ENG-0000 - Fix `doRequest()` method return value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/core",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "description": "Node Enterprise Packages for Alert Logic (NEPAL) Core Library",
   "main": "./dist/index.cjs.js",
   "types": "./dist/index.d.ts",

--- a/src/client/al-api-client.ts
+++ b/src/client/al-api-client.ts
@@ -985,7 +985,7 @@ export class AlApiClient
             console.warn(`WARNING: ignoring exception thrown in beforeRequest callback`, e );
         }
     }
-    await ax( config ).then( response => {
+    return ax( config ).then( response => {
                                 if ( attemptIndex > 0 ) {
                                   console.warn(`Notice: resolved request for ${config.url} with retry logic.` );
                                 }


### PR DESCRIPTION
The `return` was replaced with `await` incorrectly, causing the function to not return the correct value.

See breaking changeset [here](https://github.com/alertlogic/nepal-core/compare/5a6788a931871bdb0e19b4d4115ec3371a906dc7...v1).

I don't know why typescript compilation did catch this, as it is clearly not returning a value of the type described by the function declaration.